### PR TITLE
Listen to me robot

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -370,7 +370,7 @@ async function main() {
 
   // Seed a kickoff message if provided
   if (typeof kickoff === "string" && kickoff.length > 0) {
-    await scheduler.enqueueUserText(kickoff);
+    await scheduler.interject(kickoff);
   }
 
   // Start the scheduler loop. IMPORTANT: do NOT finalize here.

--- a/src/input/tty-controller.ts
+++ b/src/input/tty-controller.ts
@@ -40,8 +40,7 @@ type WritableLike = Pick<Writable, "write"> & { write(chunk: any): any };
 
 type SchedulerLike = {
   /** test fakes tend to expose one (or both) of these; call both if present */
-  enqueue?: (line: string) => void;
-  enqueueUserInput?: (line: string) => void;
+  interject: (text: string) => string;
 };
 
 /* --------------------------------- Options -------------------------------- */
@@ -292,8 +291,7 @@ export class TtyController {
   /* ----------------------------- internal bits ----------------------------- */
 
   private enqueue(line: string) {
-    this.scheduler.enqueueUserInput?.(line);
-    this.scheduler.enqueue?.(line);
+    this.scheduler.interject(line);
   }
 
   private async finalizeThenExit() {

--- a/src/scheduler/random-scheduler.ts
+++ b/src/scheduler/random-scheduler.ts
@@ -441,7 +441,7 @@ All agents are idle. Provide the next concrete instruction or question.`;
 
     // Fallback: broadcast to group
     for (const a of this.agents) {
-      this.inbox.push(a.id, { content: raw, role: "user", from: "User" });
+      this.inbox.push(a.id, { content: raw.trim(), role: "user", from: "User" });
     }
 
     Logger.debug("End of interjection");

--- a/src/scheduler/random-scheduler.ts
+++ b/src/scheduler/random-scheduler.ts
@@ -365,11 +365,6 @@ All agents are idle. Provide the next concrete instruction or question.`;
     });
   }
 
-  /** Alias for compatibility with newer callers; routes to interject(). */
-  async enqueueUserText(text: string): Promise<void> {
-    await this.interject(text);
-  }
-
   async finalizeAndReview(): Promise<void> {
     Logger.info("\n👀 Finalize and review all ...");
     try {

--- a/src/scheduler/router.ts
+++ b/src/scheduler/router.ts
@@ -53,11 +53,11 @@ export async function routeWithSideEffects(
 ): Promise<boolean> {
     const router = makeRouter({
         onAgent: async (from, to, cleaned) => {
-            Logger.info(C.blue(`[@@${from} → @@${to}]`));
+            //Logger.info(C.blue(`[@@${from} → @@${to}]`));
             deps.setRespondingAgent(to);
             if (cleaned) deps.enqueue(to, { role: "user", from: fromAgent.id, content: cleaned });
         },
-        onGroup: async (_from, cleaned) => {
+        onGroup: async (from, cleaned) => {
             const peers = deps.agents.map(a => a.id);
             const dec = fromAgent.guardCheck?.("group", cleaned, peers) || null;
             if (dec) await deps.applyGuard(fromAgent, dec);
@@ -65,14 +65,14 @@ export async function routeWithSideEffects(
                 Logger.debug(`suppress @@group from ${fromAgent.id}`);
                 return;
             }
-            Logger.info(C.blue(`[user → @@${from}] ${to}`));
+            //Logger.info(C.blue(`[user → @@${from}] @@group`));
             for (const a of deps.agents) {
                 if (a.id === fromAgent.id) continue;
                 if (cleaned) deps.enqueue(a.id, { role: "user", from: fromAgent.id, content: cleaned });
             }
         },
         onUser: async (from, _content) => {
-            Logger.info(C.blue(`[@@${from} → @@user]`));
+            //Logger.info(C.blue(`[@@${from} → @@user]`));
             // In non-interactive mode, an @@user tag should terminate cleanly
             if (!process.stdin.isTTY) {
                 try { await finalizeAllSandboxes(); } catch (e) { Logger.error(e); }

--- a/src/scheduler/router.ts
+++ b/src/scheduler/router.ts
@@ -52,7 +52,8 @@ export async function routeWithSideEffects(
     sandbox?: ISandboxSession,
 ): Promise<boolean> {
     const router = makeRouter({
-        onAgent: async (_from, to, cleaned) => {
+        onAgent: async (from, to, cleaned) => {
+            Logger.info(C.blue(`[@@${from} → @@${to}]`));
             deps.setRespondingAgent(to);
             if (cleaned) deps.enqueue(to, { role: "user", from: fromAgent.id, content: cleaned });
         },
@@ -64,12 +65,14 @@ export async function routeWithSideEffects(
                 Logger.debug(`suppress @@group from ${fromAgent.id}`);
                 return;
             }
+            Logger.info(C.blue(`[user → @@${from}] ${to}`));
             for (const a of deps.agents) {
                 if (a.id === fromAgent.id) continue;
                 if (cleaned) deps.enqueue(a.id, { role: "user", from: fromAgent.id, content: cleaned });
             }
         },
-        onUser: async (_from, _content) => {
+        onUser: async (from, _content) => {
+            Logger.info(C.blue(`[@@${from} → @@user]`));
             // In non-interactive mode, an @@user tag should terminate cleanly
             if (!process.stdin.isTTY) {
                 try { await finalizeAllSandboxes(); } catch (e) { Logger.error(e); }

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -20,6 +20,8 @@ export interface IScheduler {
   /** Drain outstanding work, then stop. */
   drain(): Promise<void>;
 
+  interject(s: string): Promise<string>;
+
   /** Enqueue a user text message. Scheduler converts text into ChatMessage. */
   enqueueUserText(text: string, opts?: { to?: string; from?: string }): Promise<void>;
 }


### PR DESCRIPTION
## Description
Fixes minor bugs.

## PR Checklist: Sandbox Matrix (8/8 must pass)

> **Pre-flight once per branch**
>
> ```bash
> # make sure the image exists
> ./create-container.sh     # or ./install.sh
>
> # start clean (optional but recommended)
> rm -rf .org/runs .org/logs
> ```
>
> All commands below assume the repo root. Replace `<CMD>` with the command you want the step to run.
> For “env propagation” checks we use `printenv | grep -E '^ORG_TEST=' || echo missing`.

### Legend

* **UI**: `--ui console` or `--ui tmux`
* **Mode**:

  * **non-interactive** → one step, captured output (uses `sandboxedSh`)
  * **interactive** → one interactive step (uses `shInteractive`)
* **Backend**:

  * **none** → no nested container; run directly in the app container
  * **podman** → nested container runner

---

### ✅ 1. console • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * `.org/logs/*` has no “posix\_spawn 'bash'” errors

* [x] PASS

---

### ✅ 2. console • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * A single container session reused across steps (check `podman ps` name is stable)

* [x] PASS

---

### ✅ 3. console • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

  > If your prompt driver doesn’t support the `interactive` keyword, trigger an interactive step via the UI or your testing harness; the key is to exercise `shInteractive`.

* **Expect**

  * Output contains `ORG_TEST=1`
  * **No** “posix\_spawn 'bash' ENOENT” anywhere

* [x] PASS

---

### ✅ 4. console • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * Still only **one** container for the app and **one** nested podman for the step (if you keep nesting enabled); or none if your launcher sets `ORG_SANDBOX_BACKEND=none`

* [ ] PASS

---

### ✅ 5. tmux • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the tmux pane, run:

  ```
  run `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **ESC** emits the ACK and exits gracefully
  * **Ctrl+C** exits immediately (130)

* [ ] PASS

---

### ✅ 6. tmux • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane, run the same `printenv` step.

* **Expect**

  * Pane prints `ORG_TEST=1`
  * ESC ACK works; Ctrl+C exits immediately
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 7. tmux • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **Typing** must not crash the app (regression test from ESC/Ctrl+C fixes)
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 8. tmux • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * No extra containers spawned when not intended (depending on your launcher policy)

* [ ] PASS

---

## Add-on checks (tick if relevant to your PR)

* [ ] **ESC ack** works in console & tmux (no double-ACK, no freeze)
* [ ] **Ctrl+C** exits with code 130
* [ ] All step artifacts exist (`.org/runs/<id>/steps/step-*.{out,err,meta.json}`)
* [ ] No “sticky runner” surprises: `/work/.org/org-step.sh` is a fresh copy if the script changed
* [ ] CI logs contain no “posix\_spawn 'bash' ENOENT” or uncaught exceptions

---

## How to use this locally

* Run each command and tick the checkbox.
* If a tmux test fails, open `.org/logs/tmux-*.log` for the run and attach to your PR.
* If a console test fails, attach `.org/logs/*` and the newest `.org/runs/<id>/steps/` files.


