### PR TITLE
Rich ui mode and cleanup

### DIFF
--- a/.orgctl
+++ b/.orgctl
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# orgctl - MIT
+# Orchestrates a VirtualBox VM for 'org' and installs the app into the VM.
+set -euo pipefail
+
+VERSION="0.2.0"
+
+# ---------- Defaults (override with env) ----------
+VM_NAME="${VM_NAME:-org-vm}"
+UBUNTU_ISO_URL="${UBUNTU_ISO_URL:-https://releases.ubuntu.com/24.04/ubuntu-24.04.1-live-server-amd64.iso}"
+WORKDIR="${WORKDIR:-$HOME/.orgvm}"
+CPU_COUNT="${CPU_COUNT:-2}"
+RAM_MB="${RAM_MB:-4096}"
+DISK_GB="${DISK_GB:-40}"
+HOST_SSH_PORT="${HOST_SSH_PORT:-2222}"
+SSH_USER="${SSH_USER:-org}"
+
+APP_DIR_IN_VM="${APP_DIR_IN_VM:-/home/${SSH_USER}/org}"
+INSTALL_SCRIPT_IN_VM="${INSTALL_SCRIPT_IN_VM:-${APP_DIR_IN_VM}/install.sh}"
+
+ORG_GIT_URL_DEFAULT="${ORG_GIT_URL_DEFAULT:-https://github.com/tjamescouch/org.git}"
+ORG_TARBALL_URL="${ORG_TARBALL_URL:-}"
+ORG_TARBALL_SHA256="${ORG_TARBALL_SHA256:-}"
+
+usage() {
+  cat <<EOF
+orgctl v${VERSION}
+
+USAGE
+  orgctl vm init                 Create & provision base VM (no app yet)
+  orgctl vm up                   Start/ensure VM is running
+  orgctl vm stop                 Gracefully power off
+  orgctl vm destroy              Remove VM and disks
+  orgctl vm ssh                  SSH into VM
+  orgctl vm export               Export OVA to ~/.orgvm/dist/${VM_NAME}.ova
+
+  orgctl app install [--from host|git|tar]
+                     [--repo URL] [--ssh-agent]
+                     [--tar-url URL --tar-sha256 SHA]
+                     [--no-run] [--exclude PATTERN ...]
+
+Defaults:
+  --from host     (rsync current folder -> ${APP_DIR_IN_VM}, then run install.sh)
+Fallbacks:
+  --from git      (clone inside VM; add --ssh-agent to avoid storing secrets)
+  --from tar      (download release tarball into VM; verify with --tar-sha256)
+
+ENV:
+  VM_NAME, CPU_COUNT, RAM_MB, DISK_GB, HOST_SSH_PORT, SSH_USER
+  WORKDIR, UBUNTU_ISO_URL
+  APP_DIR_IN_VM, INSTALL_SCRIPT_IN_VM
+  ORG_TARBALL_URL, ORG_TARBALL_SHA256
+EOF
+}
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }; }
+assert_virtualbox() { command -v VBoxManage >/dev/null 2>&1 || { echo "Install VirtualBox (brew install --cask virtualbox)" >&2; exit 1; }; }
+ensure_workdir() { mkdir -p "$WORKDIR"/{build,dist,cache,logs}; }
+
+detect_pubkey() {
+  if [[ -n "${ORG_SSH_PUBKEY:-}" ]]; then echo "$ORG_SSH_PUBKEY"; return; fi
+  for cand in "$HOME/.ssh/id_ed25519.pub" "$HOME/.ssh/id_rsa.pub"; do
+    [[ -f "$cand" ]] && { cat "$cand"; return; }
+  done
+  echo "No SSH public key found. Create one with: ssh-keygen -t ed25519" >&2; exit 1
+}
+
+download_iso() {
+  local iso="$WORKDIR/cache/$(basename "$UBUNTU_ISO_URL")"
+  [[ -f "$iso" ]] || { echo "Downloading Ubuntu ISO..."; curl -fL "$UBUNTU_ISO_URL" -o "$iso"; }
+  echo "$iso"
+}
+
+seed_iso_with() {
+  # Use genisoimage (macOS: brew install cdrtools)
+  local src="$1" out="$2"
+  if command -v genisoimage >/dev/null 2>&1; then
+    genisoimage -quiet -output "$out" -volid cidata -joliet -rock "$src/user-data" "$src/meta-data"
+  elif [[ "$(uname)" == "Darwin" ]] && command -v hdiutil >/dev/null 2>&1; then
+    # fallback for macOS if genisoimage missing
+    hdiutil makehybrid -quiet -o "$out" "$src" -iso -joliet -default-volume-name cidata
+  else
+    echo "Need genisoimage (or hdiutil on macOS) to build seed ISO" >&2; exit 1
+  fi
+}
+
+make_seed_iso() {
+  local pubkey="$1"
+  local seed="$WORKDIR/build/seed"
+  rm -rf "$seed"; mkdir -p "$seed"
+
+  cat >"$seed/user-data" <<YAML
+#cloud-config
+users:
+  - name: ${SSH_USER}
+    groups: [sudo]
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    ssh_authorized_keys: [ ${pubkey} ]
+package_update: true
+packages: [ git, curl, ca-certificates, unzip, build-essential, tmux, ufw, openssh-server, podman ]
+runcmd:
+  - [ bash, -lc, "ufw --force enable && ufw allow 22/tcp" ]
+  - [ bash, -lc, "curl -fsSL https://bun.sh/install | bash" ]
+  - [ bash, -lc, "echo 'export BUN_INSTALL=\\$HOME/.bun' >> /home/${SSH_USER}/.bashrc" ]
+  - [ bash, -lc, "echo 'export PATH=\\$BUN_INSTALL/bin:\\$PATH' >> /home/${SSH_USER}/.bashrc" ]
+YAML
+
+  cat >"$seed/meta-data" <<MD
+instance-id: ${VM_NAME}
+local-hostname: ${VM_NAME}
+MD
+
+  local iso_out="$WORKDIR/build/seed.iso"
+  seed_iso_with "$seed" "$iso_out"
+  echo "$iso_out"
+}
+
+vm_exists()  { VBoxManage list vms | grep -q "\"$VM_NAME\""; }
+vm_running() { VBoxManage list runningvms | grep -q "\"$VM_NAME\""; }
+
+wait_for_ssh() {
+  local tries=90
+  until ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p "$HOST_SSH_PORT" "${SSH_USER}@127.0.0.1" true 2>/dev/null; do
+    ((tries--)) || { echo "SSH did not come up in time"; exit 1; }
+    sleep 5
+  done
+}
+
+vm_create() {
+  local iso="$1" seed="$2"
+  echo "Creating VM ${VM_NAME}..."
+  VBoxManage createvm --name "$VM_NAME" --ostype Ubuntu_64 --register
+  VBoxManage modifyvm "$VM_NAME" --memory "$RAM_MB" --cpus "$CPU_COUNT" --ioapic on --pae on --graphicscontroller vmsvga
+  VBoxManage createmedium disk --filename "$WORKDIR/build/${VM_NAME}.vdi" --size "$((DISK_GB*1024))"
+  VBoxManage storagectl "$VM_NAME" --name "SATA" --add sata --controller IntelAhci
+  VBoxManage storageattach "$VM_NAME" --storagectl "SATA" --port 0 --device 0 --type hdd --medium "$WORKDIR/build/${VM_NAME}.vdi"
+  VBoxManage storagectl "$VM_NAME" --name "IDE" --add ide
+  VBoxManage storageattach "$VM_NAME" --storagectl "IDE" --port 0 --device 0 --type dvddrive --medium "$iso"
+  VBoxManage storageattach "$VM_NAME" --storagectl "IDE" --port 1 --device 0 --type dvddrive --medium "$seed"
+  VBoxManage modifyvm "$VM_NAME" --nic1 nat
+  VBoxManage modifyvm "$VM_NAME" --natpf1 "ssh,tcp,127.0.0.1,${HOST_SSH_PORT},,22"
+
+  echo "Starting unattended installation..."
+  VBoxManage unattended install "$VM_NAME" \
+    --iso="$iso" --user="$SSH_USER" --password="$SSH_USER" --full-user-name="$SSH_USER" \
+    --install-additions --locale="en_US" --time-zone="UTC" --start-vm=headless
+
+  wait_for_ssh
+  echo "Base system reachable; giving cloud-init a moment…"; sleep 20 || true
+}
+
+vm_detach_isos() {
+  VBoxManage storageattach "$VM_NAME" --storagectl "IDE" --port 0 --device 0 --type dvddrive --medium none || true
+  VBoxManage storageattach "$VM_NAME" --storagectl "IDE" --port 1 --device 0 --type dvddrive --medium none || true
+}
+
+vm_export() {
+  mkdir -p "$WORKDIR/dist"
+  local ova="$WORKDIR/dist/${VM_NAME}.ova"
+  echo "Exporting OVA to $ova..."
+  VBoxManage export "$VM_NAME" --output "$ova"
+  (cd "$WORKDIR/dist" && shasum -a 256 "$(basename "$ova")" > "$(basename "$ova").sha256")
+  echo "OVA ready: $ova"
+}
+
+ssh_base() { echo "-p" "$HOST_SSH_PORT" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null"; }
+
+rsync_excludes() {
+  cat <<EOF
+.git/
+node_modules/
+dist/
+build/
+.cache/
+.DS_Store
+EOF
+}
+
+# ---------- VM Commands ----------
+cmd_vm_init() {
+  assert_virtualbox; need curl
+  ensure_workdir
+  vm_exists && { echo "VM ${VM_NAME} already exists."; exit 1; }
+  local iso pubkey seed
+  iso="$(download_iso)"
+  pubkey="$(detect_pubkey)"
+  seed="$(make_seed_iso "$pubkey")"
+  vm_create "$iso" "$seed"
+  vm_detach_isos
+  echo "VM ${VM_NAME} ready. Next: orgctl app install"
+}
+
+cmd_vm_up()      { assert_virtualbox; vm_running || { VBoxManage startvm "$VM_NAME" --type headless; wait_for_ssh; }; echo "VM up."; }
+cmd_vm_stop()    { assert_virtualbox; vm_running && VBoxManage controlvm "$VM_NAME" acpipowerbutton || echo "VM not running."; }
+cmd_vm_destroy() { assert_virtualbox; vm_running && VBoxManage controlvm "$VM_NAME" poweroff || true; vm_exists && VBoxManage unregistervm "$VM_NAME" --delete || true; echo "Removed VM."; }
+cmd_vm_ssh()     { assert_virtualbox; ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1"; }
+cmd_vm_export()  { assert_virtualbox; vm_export; }
+
+# ---------- App install flows ----------
+looks_like_org_repo() {
+  [[ -f "package.json" || -f "bun.toml" || -f "bunfig.toml" ]] && [[ -d "src" || -d "scripts" || -f "install.sh" ]]
+}
+
+host_sync_into_vm() {
+  need rsync
+  local tmp_excl; tmp_excl="$(mktemp)"
+  rsync_excludes > "$tmp_excl"
+  if [[ "${#EXTRA_EXCLUDES[@]:-0}" -gt 0 ]]; then printf "%s\n" "${EXTRA_EXCLUDES[@]}" >> "$tmp_excl"; fi
+  echo "Syncing current directory to ${APP_DIR_IN_VM} ..."
+  rsync -az --delete --progress \
+    --exclude-from="$tmp_excl" \
+    -e "ssh $(ssh_base | xargs echo)" \
+    ./ "${SSH_USER}@127.0.0.1:${APP_DIR_IN_VM}/"
+  rm -f "$tmp_excl"
+}
+
+run_install_script() {
+  echo "Running ${INSTALL_SCRIPT_IN_VM} inside VM ..."
+  ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1" \
+    "bash -lc 'chmod +x ${INSTALL_SCRIPT_IN_VM} || true; ${INSTALL_SCRIPT_IN_VM}'"
+}
+
+git_clone_in_vm_https() {
+  local url="$1"
+  echo "Cloning ${url} inside the VM (HTTPS) ..."
+  set +e
+  ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1" \
+    "bash -lc 'rm -rf ${APP_DIR_IN_VM} && git clone ${url} ${APP_DIR_IN_VM}'"
+  local rc=$?; set -e; return $rc
+}
+
+git_clone_in_vm_ssh() {
+  local url="$1"
+  echo "Cloning ${url} inside the VM via SSH agent-forwarding ..."
+  ssh -A "$(ssh_base[@])" "${SSH_USER}@127.0.0.1" \
+    "bash -lc 'rm -rf ${APP_DIR_IN_VM} && git clone ${url} ${APP_DIR_IN_VM}'"
+}
+
+tarball_install_in_vm() {
+  local url="$1" sha="$2"
+  echo "Fetching tarball ${url} inside the VM ..."
+  local verify=""; [[ -n "$sha" ]] && verify="echo '${sha}  /tmp/org.tgz' | sha256sum -c - &&"
+  ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1" \
+    "bash -lc 'rm -rf ${APP_DIR_IN_VM} && mkdir -p ${APP_DIR_IN_VM} && \
+      curl -fL ${url@Q} -o /tmp/org.tgz && ${verify} \
+      tar -xzf /tmp/org.tgz -C ${APP_DIR_IN_VM} --strip-components=1'"
+}
+
+cmd_app_install() {
+  assert_virtualbox; cmd_vm_up >/dev/null
+
+  local FROM="host" REPO_URL="$ORG_GIT_URL_DEFAULT" USE_SSH_AGENT="no" NO_RUN="no"
+  EXTRA_EXCLUDES=(); local TAR_URL="$ORG_TARBALL_URL" TAR_SHA="$ORG_TARBALL_SHA256"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --from) FROM="$2"; shift 2;;
+      --repo) REPO_URL="$2"; shift 2;;
+      --ssh-agent) USE_SSH_AGENT="yes"; shift;;
+      --no-run) NO_RUN="yes"; shift;;
+      --exclude) EXTRA_EXCLUDES+=("$2"); shift 2;;
+      --tar-url) TAR_URL="$2"; shift 2;;
+      --tar-sha256) TAR_SHA="$2"; shift 2;;
+      *) echo "Unknown option: $1" >&2; usage; exit 1;;
+    esac
+  done
+
+  case "$FROM" in
+    host)
+      if looks_like_org_repo; then
+        host_sync_into_vm
+      else
+        echo "This directory doesn't look like the 'org' repo; falling back to --from git."
+        FROM="git"
+      fi
+      ;;
+  esac
+
+  if [[ "$FROM" == "git" ]]; then
+    if git_clone_in_vm_https "$REPO_URL"; then
+      echo "Git clone (HTTPS) succeeded."
+    else
+      echo
+      echo "Git clone failed (likely private repo or no creds). Choose one:"
+      echo "  1) SSH agent forwarding: orgctl app install --from git --repo git@github.com:YOU/org.git --ssh-agent"
+      echo "  2) Verified tarball:      orgctl app install --from tar --tar-url https://... --tar-sha256 <sha>"
+      echo "  3) Local sync:            run from your repo root: orgctl app install --from host"
+      echo
+      exit 2
+    fi
+  fi
+
+  if [[ "$FROM" == "tar" ]]; then
+    [[ -n "$TAR_URL" ]] || { echo "--from tar requires --tar-url"; exit 1; }
+    tarball_install_in_vm "$TAR_URL" "$TAR_SHA"
+  fi
+
+  [[ "$NO_RUN" == "yes" ]] || run_install_script
+  echo "✔ Installed at ${APP_DIR_IN_VM}"
+}
+
+# ---------- Main ----------
+case "${1:-}" in
+  vm) shift; sub="${1:-}"; shift || true
+      case "$sub" in
+        init) cmd_vm_init "$@";;
+        up) cmd_vm_up;;
+        stop) cmd_vm_stop;;
+        destroy) cmd_vm_destroy;;
+        ssh) cmd_vm_ssh;;
+        export) cmd_vm_export;;
+        *) usage; exit 1;;
+      esac;;
+  app) shift; sub="${1:-}"; shift || true
+      case "$sub" in
+        install) cmd_app_install "$@";;
+        *) usage; exit 1;;
+      esac;;
+  version) echo "$VERSION";;
+  ""|help|-h|--help) usage;;
+  *) usage; exit 1;;
+esac
+

--- a/scripts/org
+++ b/scripts/org
@@ -35,6 +35,6 @@ done
 
 case "${mode}" in
   tmux)    exec /usr/local/libexec/org/launch-tmux    "${rest[@]}" ;;
-  rich)    exec /usr/local/libexec/org/launch-console "${rest[@]}" ;;
-  console) exec /usr/local/libexec/org/launch-console "${rest[@]}" ;;
+  rich)    exec /usr/local/libexec/org/launch-console "${rest[@]} --ui rich" ;;
+  console) exec /usr/local/libexec/org/launch-console "${rest[@]} --ui console" ;;
 esac

--- a/scripts/org
+++ b/scripts/org
@@ -35,6 +35,6 @@ done
 
 case "${mode}" in
   tmux)    exec /usr/local/libexec/org/launch-tmux    "${rest[@]}" ;;
-  rich)    exec /usr/local/libexec/org/launch-console --ui rich "${rest[@]}" ;;
-  console) exec /usr/local/libexec/org/launch-console --ui console "${rest[@]}" ;;
+  rich)    exec /usr/local/libexec/org/launch-rich    "${rest[@]}" ;;
+  console) exec /usr/local/libexec/org/launch-console "${rest[@]}" ;;
 esac

--- a/scripts/org
+++ b/scripts/org
@@ -31,9 +31,10 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ "${mode}" == "tmux" || "${mode}" == "console" ]] || { echo "ERROR: --ui must be tmux|console"; exit 2; }
+[[ "${mode}" == "tmux" || "${mode}" == "console" || "${mode}" == "rich"  ]] || { echo "ERROR: --ui must be tmux|console|rich"; exit 2; }
 
 case "${mode}" in
   tmux)    exec /usr/local/libexec/org/launch-tmux    "${rest[@]}" ;;
+  rich)    exec /usr/local/libexec/org/launch-console "${rest[@]}" ;;
   console) exec /usr/local/libexec/org/launch-console "${rest[@]}" ;;
 esac

--- a/scripts/org
+++ b/scripts/org
@@ -22,9 +22,9 @@ mode="console"   # default
 rest=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --ui)       shift; [[ "${1-}" != "" ]] || { echo "ERROR: --ui requires tmux|console"; usage; exit 2; }; mode="$1"; shift ;;
+    --ui)       shift; [[ "${1-}" != "" ]] || { echo "ERROR: --ui requires tmux|console|rich"; usage; exit 2; }; mode="$1"; shift ;;
     --ui=*)     mode="${1#--ui=}"; shift ;;
-    tmux|console)
+    tmux|console|rich)
       echo "ERROR: positional '$1' not supported; use --ui $1" >&2; usage; exit 2 ;;
     -h|--help|help) usage; exit 0 ;;
     *) rest+=("$1"); shift ;;

--- a/scripts/org
+++ b/scripts/org
@@ -35,6 +35,6 @@ done
 
 case "${mode}" in
   tmux)    exec /usr/local/libexec/org/launch-tmux    "${rest[@]}" ;;
-  rich)    exec /usr/local/libexec/org/launch-console "${rest[@]} --ui rich" ;;
-  console) exec /usr/local/libexec/org/launch-console "${rest[@]} --ui console" ;;
+  rich)    exec /usr/local/libexec/org/launch-console --ui rich "${rest[@]}" ;;
+  console) exec /usr/local/libexec/org/launch-console --ui console "${rest[@]}" ;;
 esac

--- a/scripts/org-launch-console.logic.sh
+++ b/scripts/org-launch-console.logic.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # scripts/org-launch-console
-# Runs the app in console mode (default) and logs to /work/.org/logs/console.log.
-# If user passes --ui console or --ui rich, that flag is preserved verbatim.
+# Runs the app in console mode and logs to /work/.org/logs/console.log.
 
 set -Eeuo pipefail
+
 
 ORG_DIR="${ORG_RUNTIME_DIR:-/work/.org}"
 LOG_DIR="${ORG_DIR}/logs"
@@ -11,6 +11,7 @@ LOG_FILE="${LOG_DIR}/console.log"
 BUN_BIN="${ORG_BUN_BIN:-/usr/local/bin/bun}"
 APP_ENTRY="${ORG_APP_ENTRY:-/application/src/app.ts}"
 
+# Forward ALL user args verbatim to the app.
 APP_ARGS=("$@")
 
 export SANDBOX_BACKEND="${SANDBOX_BACKEND:-none}"
@@ -24,39 +25,21 @@ chmod 700 "${ORG_DIR}" || true
 [[ -x "${BUN_BIN}"  ]] || { echo "ERROR: bun not found at ${BUN_BIN}"  >&2; exit 1; }
 [[ -f "${APP_ENTRY}" ]] || { echo "ERROR: entrypoint not found: ${APP_ENTRY}" >&2; exit 42; }
 
-# Decide UI flag
-ui_val=""
-prev=""
-for arg in "${APP_ARGS[@]}"; do
-  case "$arg" in
-    --ui) prev="--ui" ;;           # handle next token
-    --ui=*) ui_val="${arg#--ui=}" ;;
-    *)
-      if [[ "$prev" == "--ui" ]]; then
-        ui_val="$arg"
-        prev=""
-      fi
-      ;;
-  esac
-done
-
-if [[ "$ui_val" == "console" || "$ui_val" == "rich" ]]; then
-  UI_FLAG=(--ui "$ui_val")
-else
-  UI_FLAG=(--ui console)
-fi
-
-# Helper for logging
-print_cmd() { printf "%q " "$@"; printf "\n"; }
+# Helper to print argv safely for logs
+print_cmd() {
+  printf "%q " "$@"
+  printf "\n"
+}
 
 {
   echo "===== org console start: $(date -Is) ====="
   printf "cmd: "
-  print_cmd "${BUN_BIN}" "${APP_ENTRY}" "${UI_FLAG[@]}" "${APP_ARGS[@]}"
+  print_cmd "${BUN_BIN}" "${APP_ENTRY}" --ui console "${APP_ARGS[@]}"
 } | tee -a "${LOG_FILE}"
 
 set +e
-"${BUN_BIN}" "${APP_ENTRY}" "${UI_FLAG[@]}" "${APP_ARGS[@]}" 2>&1 | tee -a "${LOG_FILE}"
+# Run the app, tee output, preserve the app's exit code
+"${BUN_BIN}" "${APP_ENTRY}" --ui console "${APP_ARGS[@]}" 2>&1 | tee -a "${LOG_FILE}"
 code=${PIPESTATUS[0]}
 set -e
 

--- a/scripts/org-launch-rich
+++ b/scripts/org-launch-rich
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# set -v
+
+/application/scripts/org-launch-console.logic.sh "$@"
+rc=$?
+
+# After app exits, write a patch (best-effort)
+if command -v /usr/local/bin/org-patch-create >/dev/null 2>&1; then
+  /usr/local/bin/org-patch-create || true
+fi
+
+exit "$rc"

--- a/scripts/org-launch-rich.logic.sh
+++ b/scripts/org-launch-rich.logic.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # scripts/org-launch-console
-# Runs the app in console mode (default) and logs to /work/.org/logs/console.log.
-# If user passes --ui console or --ui rich, that flag is preserved verbatim.
+# Runs the app in console mode and logs to /work/.org/logs/console.log.
 
 set -Eeuo pipefail
+
 
 ORG_DIR="${ORG_RUNTIME_DIR:-/work/.org}"
 LOG_DIR="${ORG_DIR}/logs"
@@ -11,6 +11,7 @@ LOG_FILE="${LOG_DIR}/console.log"
 BUN_BIN="${ORG_BUN_BIN:-/usr/local/bin/bun}"
 APP_ENTRY="${ORG_APP_ENTRY:-/application/src/app.ts}"
 
+# Forward ALL user args verbatim to the app.
 APP_ARGS=("$@")
 
 export SANDBOX_BACKEND="${SANDBOX_BACKEND:-none}"
@@ -24,41 +25,23 @@ chmod 700 "${ORG_DIR}" || true
 [[ -x "${BUN_BIN}"  ]] || { echo "ERROR: bun not found at ${BUN_BIN}"  >&2; exit 1; }
 [[ -f "${APP_ENTRY}" ]] || { echo "ERROR: entrypoint not found: ${APP_ENTRY}" >&2; exit 42; }
 
-# Decide UI flag
-ui_val=""
-prev=""
-for arg in "${APP_ARGS[@]}"; do
-  case "$arg" in
-    --ui) prev="--ui" ;;           # handle next token
-    --ui=*) ui_val="${arg#--ui=}" ;;
-    *)
-      if [[ "$prev" == "--ui" ]]; then
-        ui_val="$arg"
-        prev=""
-      fi
-      ;;
-  esac
-done
-
-if [[ "$ui_val" == "console" || "$ui_val" == "rich" ]]; then
-  UI_FLAG=(--ui "$ui_val")
-else
-  UI_FLAG=(--ui console)
-fi
-
-# Helper for logging
-print_cmd() { printf "%q " "$@"; printf "\n"; }
+# Helper to print argv safely for logs
+print_cmd() {
+  printf "%q " "$@"
+  printf "\n"
+}
 
 {
-  echo "===== org console start: $(date -Is) ====="
+  echo "===== org rich console start: $(date -Is) ====="
   printf "cmd: "
-  print_cmd "${BUN_BIN}" "${APP_ENTRY}" "${UI_FLAG[@]}" "${APP_ARGS[@]}"
+  print_cmd "${BUN_BIN}" "${APP_ENTRY}" --ui rich "${APP_ARGS[@]}"
 } | tee -a "${LOG_FILE}"
 
 set +e
-"${BUN_BIN}" "${APP_ENTRY}" "${UI_FLAG[@]}" "${APP_ARGS[@]}" 2>&1 | tee -a "${LOG_FILE}"
+# Run the app, tee output, preserve the app's exit code
+"${BUN_BIN}" "${APP_ENTRY}" --ui rich "${APP_ARGS[@]}" 2>&1 | tee -a "${LOG_FILE}"
 code=${PIPESTATUS[0]}
 set -e
 
-echo "===== org console exit: ${code} @ $(date -Is) =====" | tee -a "${LOG_FILE}"
+echo "===== org rich console exit: ${code} @ $(date -Is) =====" | tee -a "${LOG_FILE}"
 exit "${code}"

--- a/scripts/org-launch-rich.logic.sh
+++ b/scripts/org-launch-rich.logic.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# scripts/org-launch-console
+# Runs the app in console mode (default) and logs to /work/.org/logs/console.log.
+# If user passes --ui console or --ui rich, that flag is preserved verbatim.
+
+set -Eeuo pipefail
+
+ORG_DIR="${ORG_RUNTIME_DIR:-/work/.org}"
+LOG_DIR="${ORG_DIR}/logs"
+LOG_FILE="${LOG_DIR}/console.log"
+BUN_BIN="${ORG_BUN_BIN:-/usr/local/bin/bun}"
+APP_ENTRY="${ORG_APP_ENTRY:-/application/src/app.ts}"
+
+APP_ARGS=("$@")
+
+export SANDBOX_BACKEND="${SANDBOX_BACKEND:-none}"
+export ORG_SANDBOX_BACKEND="${ORG_SANDBOX_BACKEND:-none}"
+export ORG_EXTERNAL_TMUX_BOOTSTRAP=1
+export EDITOR=true VISUAL=true GIT_EDITOR=true PAGER=cat
+
+mkdir -p "${LOG_DIR}"
+chmod 700 "${ORG_DIR}" || true
+
+[[ -x "${BUN_BIN}"  ]] || { echo "ERROR: bun not found at ${BUN_BIN}"  >&2; exit 1; }
+[[ -f "${APP_ENTRY}" ]] || { echo "ERROR: entrypoint not found: ${APP_ENTRY}" >&2; exit 42; }
+
+# Decide UI flag
+ui_val=""
+prev=""
+for arg in "${APP_ARGS[@]}"; do
+  case "$arg" in
+    --ui) prev="--ui" ;;           # handle next token
+    --ui=*) ui_val="${arg#--ui=}" ;;
+    *)
+      if [[ "$prev" == "--ui" ]]; then
+        ui_val="$arg"
+        prev=""
+      fi
+      ;;
+  esac
+done
+
+if [[ "$ui_val" == "console" || "$ui_val" == "rich" ]]; then
+  UI_FLAG=(--ui "$ui_val")
+else
+  UI_FLAG=(--ui console)
+fi
+
+# Helper for logging
+print_cmd() { printf "%q " "$@"; printf "\n"; }
+
+{
+  echo "===== org console start: $(date -Is) ====="
+  printf "cmd: "
+  print_cmd "${BUN_BIN}" "${APP_ENTRY}" "${UI_FLAG[@]}" "${APP_ARGS[@]}"
+} | tee -a "${LOG_FILE}"
+
+set +e
+"${BUN_BIN}" "${APP_ENTRY}" "${UI_FLAG[@]}" "${APP_ARGS[@]}" 2>&1 | tee -a "${LOG_FILE}"
+code=${PIPESTATUS[0]}
+set -e
+
+echo "===== org console exit: ${code} @ $(date -Is) =====" | tee -a "${LOG_FILE}"
+exit "${code}"

--- a/src/agents/llm-agent.ts
+++ b/src/agents/llm-agent.ts
@@ -176,7 +176,7 @@ export class LlmAgent extends Agent {
 
     // --- Streaming filter: RAW when DEBUG=1/true/yes; FILTERED otherwise ---
     const dbg = (R.env.DEBUG ?? "").trim().toLowerCase();
-    const dbg2 = (process.env.LOG_LEVEL || '').toUpperCase() === 'DEBUG';
+    const dbg2 = (R.env.LOG_LEVEL || '').toUpperCase() === 'DEBUG';
     let debugStreaming = (dbg === "1") || (dbg === "true") || (dbg === "yes");
     if (dbg2) {
       debugStreaming = true;
@@ -186,7 +186,8 @@ export class LlmAgent extends Agent {
       model: this.model,
       tools: this.tools,
       onReasoningToken: t => {
-        if (R.env.ORG_HIDE_COT) {
+        const hideCot = !R.env.ORG_HIDE_COT && (String(R.env.DEBUG || "").trim() !== "1");
+        if (hideCot) {
           Logger.streamInfo(C.cyan('.'));
           return;
         }

--- a/src/app.ts
+++ b/src/app.ts
@@ -266,10 +266,11 @@ async function main() {
 
   // Pretty, TTY-aware banner (falls back to simple lines if not a TTY)
   printInitCard("org", [
-    { label: "host cwd", value: C.bold(hostStartDir) },
-    { label: "proj dir", value: C.bold(projectDir) },
-    { label: "work dir", value: C.bold(workDir) },
-    { label: "R.cwd",    value: `${C.bold(R.cwd())} ${C.gray(`PWD=${R.env.PWD ?? ""}`)}` },
+    { label: "host cwd",   value: C.bold(hostStartDir) },
+    { label: "proj dir",   value: C.bold(projectDir) },
+    { label: "work dir",   value: C.bold(workDir) },
+    { label: "R.cwd",      value: `${C.bold(R.cwd())}` },
+    { label: "R.env.PWD",  value: `${C.bold(R.env.PWD as string)}` },
   ]);
 
   const recipeName = (typeof args["recipe"] === "string" && args["recipe"]) || (R.env.ORG_RECIPE || "");

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import * as fsp from "fs/promises";
 import * as path from "path";
 import { execFileSync, spawn } from "child_process";
 
+
 import { R } from "./runtime/runtime";
 import { ExecutionGate } from "./tools/execution-gate";
 import { loadConfig } from "./config/config";

--- a/src/app.ts
+++ b/src/app.ts
@@ -62,8 +62,8 @@ const uninstallHotkeys = installHotkeys({
   stdin: R.stdin as any,
   onEsc: async () => { await R.ttyController?.unwind(); /* finalizer handles review+exit */ },
   onCtrlC: () => { Logger.error("SIGINT"); R.exit(130); },
-  feedback: process.stderr,
-  debug: !!process.env.DEBUG,
+  feedback: R.stderr,
+  debug: !!R.env.DEBUG,
 });
 
 /** Scoped helpers that return promises (safe to `await`). */
@@ -249,7 +249,7 @@ async function finalizeOnce(scheduler: SchedulerLike | null, workDir: string, re
 
 async function main() {
   const cfg = loadConfig();
-  const argv = ((globalThis as unknown as { Bun?: unknown }).Bun ? Bun.argv.slice(2) : R.argv.slice(2));
+  const argv = R.argv.slice(2);
   const args = parseArgs(argv);
 
   // tmux handoff

--- a/src/app.ts
+++ b/src/app.ts
@@ -79,27 +79,6 @@ export async function withRawTTY<T>(f: () => Promise<T> | T): Promise<T> {
   return ctl.withRawTTY(f);
 }
 
-// ───────────────────────────────────────────────────────────────────────────────
-// Args & config
-// ───────────────────────────────────────────────────────────────────────────────
-
-function parseArgs(argv: string[]) {
-  const out: Record<string, string | boolean> = {};
-  let key: string | null = null;
-  for (const a of argv) {
-    if (a.startsWith("--")) {
-      const [k, v] = a.slice(2).split("=", 2);
-      if (typeof v === "string") out[k] = v;
-      else { key = k; out[k] = true; }
-    } else if (key) {
-      out[key] = a; key = null;
-    } else {
-      if (!("prompt" in out)) out["prompt"] = a;
-      else out[`arg${Object.keys(out).length}`] = a;
-    }
-  }
-  return out;
-}
 
 function assertIsRepository(p: string): string {
   let d = path.resolve(p);
@@ -251,7 +230,7 @@ async function finalizeOnce(scheduler: SchedulerLike | null, workDir: string, re
 async function main() {
   const cfg = loadConfig();
   const argv = R.argv.slice(2);
-  const args = parseArgs(argv);
+  const args = R.args;
 
   // tmux handoff
   if (args["ui"] === "tmux" && R.env.ORG_TMUX !== "1") {

--- a/src/ui/pretty.ts
+++ b/src/ui/pretty.ts
@@ -5,11 +5,11 @@ import { R } from "../runtime/runtime";
 type Row = { label: string; value: string };
 
 function getTty() {
-  const force = R.env.ORG_FORCE_TTY === "1";
+  const isPretty = R.isPretty();
   const out = (R.stdout as any);
   const err = (R.stderr as any);
   const isTTY = !!out?.isTTY || !!err?.isTTY;
-  const tty = force ? true : isTTY;
+  const tty = isPretty ? true : isTTY;
   const columns = (tty && (out?.columns || err?.columns)) || 80;
   return { tty, columns: Math.max(40, Math.min(100, Number(columns))) };
 }
@@ -17,13 +17,10 @@ function getTty() {
 export function printInitCard(title: string, rows: Row[]): void {
   const { tty, columns } = getTty();
 
-  Logger.info("here")
   if (!tty) {
-  Logger.info("here 2")
     for (const r of rows) Logger.info(`[${title}] ${r.label} = ${r.value}`);
     return;
   }
-  Logger.info("here 3")
 
   const border = "─".repeat(columns - 2);
   const maxLabel = rows.reduce((m, r) => Math.max(m, r.label.length), 0);

--- a/src/ui/pretty.ts
+++ b/src/ui/pretty.ts
@@ -1,0 +1,37 @@
+// src/ui/pretty.ts
+// Minimal, dependency-free helpers to render a cleaner startup banner.
+//
+// Design goals:
+// - No new npm deps; ANSI only.
+// - TTY-aware: falls back to simple [org] k=v lines when not a TTY.
+// - Conservative width usage; never throws if `columns` is missing.
+
+import { C, Logger } from "../logger";
+import { R } from "../runtime/runtime";
+
+type Row = { label: string; value: string };
+
+/** Render a compact "status card" with aligned key/value rows. */
+export function printInitCard(title: string, rows: Row[]): void {
+  // Non-interactive: keep the previous simple lines for log parsers.
+  const out = R.stdout as undefined | (NodeJS.WriteStream & { columns?: number });
+  if (!out?.isTTY) {
+    for (const r of rows) Logger.info(`[${title}] ${r.label} = ${r.value}`);
+    return;
+  }
+
+  const cols = Math.max(40, Math.min(100, Number(out.columns || 80)));
+  const border = "─".repeat(cols - 2);
+
+  const maxLabel = rows.reduce((m, r) => Math.max(m, r.label.length), 0);
+  const pad = (s: string, n: number) => s + " ".repeat(Math.max(0, n - s.length));
+
+  Logger.info(`${C.gray("┌" + border)}`);
+  // header line — intentionally subtle
+  Logger.info(`${C.gray("│")} ${C.bold(C.magenta(title))}`);
+  for (const r of rows) {
+    const l = pad(r.label, maxLabel);
+    Logger.info(`${C.gray("│")} ${C.gray(l)}  ${r.value}`);
+  }
+  Logger.info(`${C.gray("└" + border)}`);
+}

--- a/src/ui/pretty.ts
+++ b/src/ui/pretty.ts
@@ -17,10 +17,13 @@ function getTty() {
 export function printInitCard(title: string, rows: Row[]): void {
   const { tty, columns } = getTty();
 
+  Logger.info("here")
   if (!tty) {
+  Logger.info("here 2")
     for (const r of rows) Logger.info(`[${title}] ${r.label} = ${r.value}`);
     return;
   }
+  Logger.info("here 3")
 
   const border = "─".repeat(columns - 2);
   const maxLabel = rows.reduce((m, r) => Math.max(m, r.label.length), 0);

--- a/src/ui/pretty.ts
+++ b/src/ui/pretty.ts
@@ -1,37 +1,47 @@
 // src/ui/pretty.ts
-// Minimal, dependency-free helpers to render a cleaner startup banner.
-//
-// Design goals:
-// - No new npm deps; ANSI only.
-// - TTY-aware: falls back to simple [org] k=v lines when not a TTY.
-// - Conservative width usage; never throws if `columns` is missing.
+// Dependency-free banner. Works even if a custom stream masks TTY-ness.
 
-import { C, Logger } from "../logger";
+import { Logger, C } from "../logger";
 import { R } from "../runtime/runtime";
 
 type Row = { label: string; value: string };
 
-/** Render a compact "status card" with aligned key/value rows. */
+function getTtyInfo() {
+  // Prefer real Node streams; fall back to runtime’s streams.
+  // Allow forcing interactivity via ORG_FORCE_TTY=1 (useful in containers).
+  const force = R.env.ORG_FORCE_TTY === "1";
+  const out = (R.stdout as NodeJS.WriteStream | undefined) ?? (R.stdout as any);
+  const err = (R.stderr as NodeJS.WriteStream | undefined) ?? (R.stderr as any);
+  const anyTty = !!(out && (out as any).isTTY) || !!(err && (err as any).isTTY);
+
+  const tty = force ? true : anyTty;
+  const columns =
+    (tty && typeof (out as any)?.columns === "number" && (out as any).columns) ||
+    (tty && typeof (err as any)?.columns === "number" && (err as any).columns) ||
+    80;
+
+  return { tty, columns: Math.max(40, Math.min(100, Number(columns))) };
+}
+
+/** Render a compact, aligned key/value "status card". */
 export function printInitCard(title: string, rows: Row[]): void {
-  // Non-interactive: keep the previous simple lines for log parsers.
-  const out = R.stdout as undefined | (NodeJS.WriteStream & { columns?: number });
-  if (!out?.isTTY) {
+  const { tty, columns } = getTtyInfo();
+
+  if (!tty) {
+    // Non-interactive: log terse k=v lines (grep-friendly).
     for (const r of rows) Logger.info(`[${title}] ${r.label} = ${r.value}`);
     return;
   }
 
-  const cols = Math.max(40, Math.min(100, Number(out.columns || 80)));
-  const border = "─".repeat(cols - 2);
-
+  const border = "─".repeat(columns - 2);
   const maxLabel = rows.reduce((m, r) => Math.max(m, r.label.length), 0);
   const pad = (s: string, n: number) => s + " ".repeat(Math.max(0, n - s.length));
 
-  Logger.info(`${C.gray("┌" + border)}`);
-  // header line — intentionally subtle
+  Logger.info(C.gray("┌" + border));
   Logger.info(`${C.gray("│")} ${C.bold(C.magenta(title))}`);
   for (const r of rows) {
     const l = pad(r.label, maxLabel);
     Logger.info(`${C.gray("│")} ${C.gray(l)}  ${r.value}`);
   }
-  Logger.info(`${C.gray("└" + border)}`);
+  Logger.info(C.gray("└" + border));
 }

--- a/src/ui/prompt-label.ts
+++ b/src/ui/prompt-label.ts
@@ -1,4 +1,5 @@
 import { R } from "../runtime/runtime";
+import { C } from "../logger";
 
 // src/ui/prompt-label.ts
 interface PromptLabelOptions {
@@ -6,9 +7,19 @@ interface PromptLabelOptions {
   separator?: string;  // default ': '
 }
 
-/** Resolve the username from env or default, and format as "<username>: ". */
+/**
+ * Resolve the username from env or default, and format as "<username>: ".
+ * If ORG_PRETTY_PROMPT=1 and stdout is a TTY, we lightly color the prompt.
+ */
 export function formatPromptLabel(opts?: PromptLabelOptions): string {
   const username = (opts?.username ?? R.env.ORG_USERNAME ?? "user").trim() || "user";
   const separator = opts?.separator ?? ": ";
-  return `${username}${separator}`;
+  const plain = `${username}${separator}`;
+
+  const out = (R.stdout as undefined | (NodeJS.WriteStream & { isTTY?: boolean })) || undefined;
+  const pretty = (R.env.ORG_PRETTY_PROMPT === "1") && !!out?.isTTY;
+  if (pretty) {
+    return C.bold(C.green(username)) + C.gray(separator);
+  }
+  return plain;
 }

--- a/src/ui/prompt-label.ts
+++ b/src/ui/prompt-label.ts
@@ -6,10 +6,6 @@ export function formatPromptLabel(username?: string, separator = ": "): string {
   const name = (username ?? R.env.ORG_USERNAME ?? "user").trim() || "user";
   const plain = `${name}${separator}`;
   const pretty = R.env.ORG_PRETTY_PROMPT === "1";
-  const tty = !!(R.stdout && (R.stdout as any).isTTY);
-
-  if (pretty && tty) {
-    return C.bold(C.green(name)) + C.gray(separator);
-  }
-  return plain;
+  const tty = !!(R.stdout as any)?.isTTY;
+  return pretty && tty ? C.bold(C.green(name)) + C.gray(separator) : plain;
 }

--- a/src/ui/prompt-label.ts
+++ b/src/ui/prompt-label.ts
@@ -1,25 +1,15 @@
+// src/ui/prompt-label.ts
 import { R } from "../runtime/runtime";
 import { C } from "../logger";
 
-// src/ui/prompt-label.ts
-interface PromptLabelOptions {
-  username?: string;   // default 'user'
-  separator?: string;  // default ': '
-}
+export function formatPromptLabel(username?: string, separator = ": "): string {
+  const name = (username ?? R.env.ORG_USERNAME ?? "user").trim() || "user";
+  const plain = `${name}${separator}`;
+  const pretty = R.env.ORG_PRETTY_PROMPT === "1";
+  const tty = !!(R.stdout && (R.stdout as any).isTTY);
 
-/**
- * Resolve the username from env or default, and format as "<username>: ".
- * If ORG_PRETTY_PROMPT=1 and stdout is a TTY, we lightly color the prompt.
- */
-export function formatPromptLabel(opts?: PromptLabelOptions): string {
-  const username = (opts?.username ?? R.env.ORG_USERNAME ?? "user").trim() || "user";
-  const separator = opts?.separator ?? ": ";
-  const plain = `${username}${separator}`;
-
-  const out = (R.stdout as undefined | (NodeJS.WriteStream & { isTTY?: boolean })) || undefined;
-  const pretty = (R.env.ORG_PRETTY_PROMPT === "1") && !!out?.isTTY;
-  if (pretty) {
-    return C.bold(C.green(username)) + C.gray(separator);
+  if (pretty && tty) {
+    return C.bold(C.green(name)) + C.gray(separator);
   }
   return plain;
 }


### PR DESCRIPTION
## Description
< Enter a description >


## PR Checklist: Sandbox Matrix (8/8 must pass)

> **Pre-flight once per branch**
>
> ```bash
> # make sure the image exists
> ./create-container.sh     # or ./install.sh
>
> # start clean (optional but recommended)
> rm -rf .org/runs .org/logs
> ```
>
> All commands below assume the repo root. Replace `<CMD>` with the command you want the step to run.
> For “env propagation” checks we use `printenv | grep -E '^ORG_TEST=' || echo missing`.

### Legend

* **UI**: `--ui console` or `--ui tmux`
* **Mode**:

  * **non-interactive** → one step, captured output (uses `sandboxedSh`)
  * **interactive** → one interactive step (uses `shInteractive`)
* **Backend**:

  * **none** → no nested container; run directly in the app container
  * **podman** → nested container runner

---

### ✅ 1. console • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * `.org/logs/*` has no “posix\_spawn 'bash'” errors

* [ ] PASS

---

### ✅ 2. console • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * A single container session reused across steps (check `podman ps` name is stable)

* [ ] PASS

---

### ✅ 3. console • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

  > If your prompt driver doesn’t support the `interactive` keyword, trigger an interactive step via the UI or your testing harness; the key is to exercise `shInteractive`.

* **Expect**

  * Output contains `ORG_TEST=1`
  * **No** “posix\_spawn 'bash' ENOENT” anywhere

* [ ] PASS

---

### ✅ 4. console • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * Still only **one** container for the app and **one** nested podman for the step (if you keep nesting enabled); or none if your launcher sets `ORG_SANDBOX_BACKEND=none`

* [ ] PASS

---

### ✅ 5. tmux • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the tmux pane, run:

  ```
  run `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **ESC** emits the ACK and exits gracefully
  * **Ctrl+C** exits immediately (130)

* [ ] PASS

---

### ✅ 6. tmux • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane, run the same `printenv` step.

* **Expect**

  * Pane prints `ORG_TEST=1`
  * ESC ACK works; Ctrl+C exits immediately
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 7. tmux • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **Typing** must not crash the app (regression test from ESC/Ctrl+C fixes)
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 8. tmux • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * No extra containers spawned when not intended (depending on your launcher policy)

* [ ] PASS

---

## Add-on checks (tick if relevant to your PR)

* [ ] **ESC ack** works in console & tmux (no double-ACK, no freeze)
* [ ] **Ctrl+C** exits with code 130
* [ ] All step artifacts exist (`.org/runs/<id>/steps/step-*.{out,err,meta.json}`)
* [ ] No “sticky runner” surprises: `/work/.org/org-step.sh` is a fresh copy if the script changed
* [ ] CI logs contain no “posix\_spawn 'bash' ENOENT” or uncaught exceptions

---

## How to use this locally

* Run each command and tick the checkbox.
* If a tmux test fails, open `.org/logs/tmux-*.log` for the run and attach to your PR.
* If a console test fails, attach `.org/logs/*` and the newest `.org/runs/<id>/steps/` files.


