### PR TITLE
Add VM configuration guide for Lima and VirtualBox

### DIFF
--- a/docs/VM_CONFIGURATION.md
+++ b/docs/VM_CONFIGURATION.md
@@ -1,0 +1,92 @@
+
+````markdown
+# VM Guide (Lima / VirtualBox)
+
+This project supports running in a **VM-backed sandbox** for a stronger boundary than host or container alone. The VM path preserves org’s core guarantees (patch-review, artifacts, deny-first policy) while putting a kernel boundary around the run. :contentReference[oaicite:0]{index=0} :contentReference[oaicite:1]{index=1}
+
+---
+
+## Quick Start (Apple Silicon → Lima)
+
+> Prereqs: `brew install lima` (Lima 1.2.x works), repo contains `.org/config/org.lima.yaml`.
+
+```bash
+# from the repo root
+./orgctl vm init    # creates/starts the Lima VM from .org/config/org.lima.yaml
+./orgctl vm ssh     # open a shell in the VM (Lima 1.2.x attaches as your macOS username)
+````
+
+Your host `~/dev` is mounted at `~/dev` in the guest. `~/scratch` is tmpfs for ephemeral work. The Lima profile defaults to **no external networking** in Lima and enforces **localhost-only** egress inside the guest via UFW (good match for LMStudio/Ollama).
+
+**Day-to-day:**
+
+```bash
+./orgctl vm up
+./orgctl vm ssh
+# inside VM
+cd ~/dev/your-repo && bun install && bun run org --ui console
+# when done
+./orgctl vm stop
+```
+
+---
+
+## Quick Start (Intel → VirtualBox)
+
+On Intel hosts we keep a VirtualBox backend for parity with non-ARM machines. Use the same `orgctl vm …` commands; orgctl auto-selects the backend by architecture.
+
+> Note: on Apple Silicon VirtualBox is not a practical option; use Lima.
+
+---
+
+## Security model (at a glance)
+
+| Layer                       | Boundary Strength | What it protects                                                            |
+| --------------------------- | ----------------- | --------------------------------------------------------------------------- |
+| Host only                   | ❌ weak            | No isolation; **not** recommended for agents that write/run code.           |
+| Rootless container (Podman) | ✅ good            | Read-only source mount + controlled write surface + no network by default.  |
+| **VM (Lima/VirtualBox)**    | ✅✅ strongest      | Separate kernel and disk; only the mounts you choose are visible.           |
+
+**VM defaults in this repo**
+
+* **Mounts**: host `~/dev →` guest `~/dev` (sane default so agents only see code, not your whole home).
+* **Scratch**: `~/scratch` tmpfs (ephemeral, safe for untrusted outputs).
+* **Network**: Lima VM has **no external networking**; UFW allows only `127.0.0.1` for LMStudio/Ollama.
+* **Review loop**: all changes still land as patch review before touching your repo.&#x20;
+
+> If you need a tighter box, mount a single project path (e.g., `~/dev/myrepo`), or make the mount read-only and `scp` in changes. For a looser dev box, you can allow outbound to curated hosts only.
+
+---
+
+## Troubleshooting
+
+**“orgctl vm ssh shows VirtualBox message on Apple Silicon”**
+You’re invoking the wrong `orgctl` on PATH (old Homebrew copy). Use `./orgctl vm ssh`, or run `type -a orgctl` and prefer the repo’s script.
+
+**Stuck on Lima boot logs**
+That’s normal for Lima 1.2.x when starting. Press **Ctrl+C** to detach, then run `./orgctl vm ssh`.
+
+**Can’t find the instance**
+`limactl list` to verify `org.lima` exists. Recreate with `./orgctl vm init`.
+
+**Where are my files?**
+Inside the VM: your host dev workspace is at `~/dev`. The VM root disk size is what you set in `.org/config/org.lima.yaml` (e.g., `50GiB`); `df -h /` shows that. A mounted host dir will report host free space; that’s expected.
+
+---
+
+## Other VM options
+
+* **Lima (recommended on Apple Silicon)** — lightweight, declarative profiles, integrates neatly with dev workflows.
+* **VirtualBox (Intel)** — traditional hypervisor; keeps guest fully air-gapped unless you add shared folders.
+* **UTM / Apple Virtualization** — also viable on Apple Silicon if you prefer a GUI; not wired into `orgctl` by default.
+
+---
+
+## How this fits org’s philosophy
+
+* **Human-in-the-loop**: every change is a reviewed patch, regardless of backend.&#x20;
+* **Sandbox first**: VM is the “hard boundary”; containers remain available for speed.&#x20;
+* **Portable installs**: host-only still works; container/VM paths are documented for safety and repeatability. &#x20;
+
+````
+


### PR DESCRIPTION
## Description
< Enter a description >


## PR Checklist: Sandbox Matrix (8/8 must pass)

> **Pre-flight once per branch**
>
> ```bash
> # make sure the image exists
> ./create-container.sh     # or ./install.sh
>
> # start clean (optional but recommended)
> rm -rf .org/runs .org/logs
> ```
>
> All commands below assume the repo root. Replace `<CMD>` with the command you want the step to run.
> For “env propagation” checks we use `printenv | grep -E '^ORG_TEST=' || echo missing`.

### Legend

* **UI**: `--ui console` or `--ui tmux`
* **Mode**:

  * **non-interactive** → one step, captured output (uses `sandboxedSh`)
  * **interactive** → one interactive step (uses `shInteractive`)
* **Backend**:

  * **none** → no nested container; run directly in the app container
  * **podman** → nested container runner

---

### ✅ 1. console • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * `.org/logs/*` has no “posix\_spawn 'bash'” errors

* [ ] PASS

---

### ✅ 2. console • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * A single container session reused across steps (check `podman ps` name is stable)

* [ ] PASS

---

### ✅ 3. console • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

  > If your prompt driver doesn’t support the `interactive` keyword, trigger an interactive step via the UI or your testing harness; the key is to exercise `shInteractive`.

* **Expect**

  * Output contains `ORG_TEST=1`
  * **No** “posix\_spawn 'bash' ENOENT” anywhere

* [ ] PASS

---

### ✅ 4. console • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * Still only **one** container for the app and **one** nested podman for the step (if you keep nesting enabled); or none if your launcher sets `ORG_SANDBOX_BACKEND=none`

* [ ] PASS

---

### ✅ 5. tmux • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the tmux pane, run:

  ```
  run `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **ESC** emits the ACK and exits gracefully
  * **Ctrl+C** exits immediately (130)

* [ ] PASS

---

### ✅ 6. tmux • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane, run the same `printenv` step.

* **Expect**

  * Pane prints `ORG_TEST=1`
  * ESC ACK works; Ctrl+C exits immediately
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 7. tmux • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **Typing** must not crash the app (regression test from ESC/Ctrl+C fixes)
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 8. tmux • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * No extra containers spawned when not intended (depending on your launcher policy)

* [ ] PASS

---

## Add-on checks (tick if relevant to your PR)

* [ ] **ESC ack** works in console & tmux (no double-ACK, no freeze)
* [ ] **Ctrl+C** exits with code 130
* [ ] All step artifacts exist (`.org/runs/<id>/steps/step-*.{out,err,meta.json}`)
* [ ] No “sticky runner” surprises: `/work/.org/org-step.sh` is a fresh copy if the script changed
* [ ] CI logs contain no “posix\_spawn 'bash' ENOENT” or uncaught exceptions

---

## How to use this locally

* Run each command and tick the checkbox.
* If a tmux test fails, open `.org/logs/tmux-*.log` for the run and attach to your PR.
* If a console test fails, attach `.org/logs/*` and the newest `.org/runs/<id>/steps/` files.


