### PR TITLE
Lima installer

### DIFF
--- a/.org/config/org.lima.yaml
+++ b/.org/config/org.lima.yaml
@@ -1,31 +1,27 @@
 # .org/config/org.lima.yaml
-# Lima profile for `org` VM
-# - Root disk: 50 GiB
-# - Mounts:
-#     host ~/dev   -> guest /home/org/dev
-#     tmpfs scratch -> guest /home/org/scratch
-# - Networking: disabled in Lima config, but ufw restricts guest
-# - User: fixed "org"
-
 arch: aarch64
 images:
   - location: "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-arm64.img"
 
 disk: 50GiB
 
-# Disable Lima-provided networking (no external connectivity)
-networks: []
+# Minimal networking for apt-get; UFW will lock down after provisioning
+networks:
+  - lima: shared
 
 mounts:
-  # Development workspace
+  # Host ~/dev -> Guest ~/dev
   - location: "~/dev"
-    mountPoint: "/home/org/dev"
+    mountPoint: "/home/{{.User}}.linux/dev"
     writable: true
 
-  # Scratch space (ephemeral tmpfs)
+  # Ephemeral scratch
   - location: "tmpfs"
-    mountPoint: "/home/org/scratch"
+    mountPoint: "/home/{{.User}}.linux/scratch"
     writable: true
+
+ssh:
+  loadDotSSHPubKeys: true
 
 provision:
   - mode: system
@@ -34,14 +30,16 @@ provision:
       apt-get install -y curl git ufw podman openssh-server sudo
       systemctl enable --now ssh
 
-      # Hardened defaults, but explicitly open SSH *inbound*
+      # UFW policy
       ufw default deny incoming
       ufw default deny outgoing
-      ufw allow 22/tcp             # <-- allow SSH IN
-      ufw allow out to 127.0.0.1   # allow LMStudio/Ollama on host
+      ufw allow 22/tcp
+      ufw allow out to 127.0.0.1
       ufw --force enable
+
   - mode: user
     script: |
+      mkdir -p "$HOME/dev"
       curl -fsSL https://bun.sh/install | bash
       echo 'export BUN_INSTALL=$HOME/.bun' >> ~/.bashrc
       echo 'export PATH=$BUN_INSTALL/bin:$PATH' >> ~/.bashrc

--- a/.org/config/org.lima.yaml
+++ b/.org/config/org.lima.yaml
@@ -28,28 +28,20 @@ mounts:
     writable: true
 
 provision:
-  # Create and configure fixed "org" user
   - mode: system
     script: |
       apt-get update
-      apt-get install -y curl git ufw podman sudo
+      apt-get install -y curl git ufw podman openssh-server sudo
+      systemctl enable --now ssh
 
-      # Create 'org' user if missing
-      if ! id -u org >/dev/null 2>&1; then
-        adduser --disabled-password --gecos "" org
-        usermod -aG sudo org
-        echo 'org ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-      fi
-
-      # Configure firewall: deny everything except localhost
+      # Hardened defaults, but explicitly open SSH *inbound*
+      ufw default deny incoming
       ufw default deny outgoing
-      ufw allow out to 127.0.0.1
+      ufw allow 22/tcp             # <-- allow SSH IN
+      ufw allow out to 127.0.0.1   # allow LMStudio/Ollama on host
       ufw --force enable
-
-  # Run setup as "org" user
   - mode: user
     script: |
-      # Install Bun
       curl -fsSL https://bun.sh/install | bash
       echo 'export BUN_INSTALL=$HOME/.bun' >> ~/.bashrc
       echo 'export PATH=$BUN_INSTALL/bin:$PATH' >> ~/.bashrc

--- a/.org/config/org.lma.bootstrap.yaml
+++ b/.org/config/org.lma.bootstrap.yaml
@@ -28,3 +28,8 @@ provision:
       curl -fsSL https://bun.sh/install | bash || true
       echo 'export BUN_INSTALL=$HOME/.bun' >> ~/.bashrc
       echo 'export PATH=$BUN_INSTALL/bin:$PATH' >> ~/.bashrc
+  - mode: user
+    script: |
+      mkdir -p "$HOME/dev"
+      [ -d "/Users/$USER/dev" ] && ln -snf "/Users/$USER/dev" "$HOME/dev"
+

--- a/.org/config/org.lma.bootstrap.yaml
+++ b/.org/config/org.lma.bootstrap.yaml
@@ -1,0 +1,30 @@
+arch: aarch64
+images:
+  - location: "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-arm64.img"
+
+disk: 50GiB
+networks:
+  - lima: shared                       # requires socket_vmnet running
+
+mounts:
+  - location: "~/dev"                  # host → guest
+    mountPoint: "/home/${USER}/dev"
+    writable: true
+  - location: "tmpfs"
+    mountPoint: "/home/${USER}/scratch"
+    writable: true
+
+ssh:
+  loadDotSSHPubKeys: true              # inject your ~/.ssh/*.pub for passwordless ssh
+
+provision:
+  - mode: system
+    script: |
+      apt-get update
+      apt-get install -y curl git sudo openssh-server podman
+      systemctl enable --now ssh
+  - mode: user
+    script: |
+      curl -fsSL https://bun.sh/install | bash || true
+      echo 'export BUN_INSTALL=$HOME/.bun' >> ~/.bashrc
+      echo 'export PATH=$BUN_INSTALL/bin:$PATH' >> ~/.bashrc

--- a/etc_sudoers.d_lima
+++ b/etc_sudoers.d_lima
@@ -1,0 +1,19 @@
+%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: /bin/mkdir -m 775 -p /private/var/run/lima
+
+# Manage "bridged" network daemons
+
+%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: \
+    /opt/socket_vmnet/bin/socket_vmnet --pidfile=/private/var/run/lima/bridged_socket_vmnet.pid --socket-group=everyone --vmnet-mode=bridged --vmnet-interface=en0 /private/var/run/lima/socket_vmnet.bridged, \
+    /usr/bin/pkill -F /private/var/run/lima/bridged_socket_vmnet.pid
+
+# Manage "host" network daemons
+
+%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: \
+    /opt/socket_vmnet/bin/socket_vmnet --pidfile=/private/var/run/lima/host_socket_vmnet.pid --socket-group=everyone --vmnet-mode=host --vmnet-gateway=192.168.106.1 --vmnet-dhcp-end=192.168.106.254 --vmnet-mask=255.255.255.0 /private/var/run/lima/socket_vmnet.host, \
+    /usr/bin/pkill -F /private/var/run/lima/host_socket_vmnet.pid
+
+# Manage "shared" network daemons
+
+%everyone ALL=(root:wheel) NOPASSWD:NOSETENV: \
+    /opt/socket_vmnet/bin/socket_vmnet --pidfile=/private/var/run/lima/shared_socket_vmnet.pid --socket-group=everyone --vmnet-mode=shared --vmnet-gateway=192.168.105.1 --vmnet-dhcp-end=192.168.105.254 --vmnet-mask=255.255.255.0 /private/var/run/lima/socket_vmnet.shared, \
+    /usr/bin/pkill -F /private/var/run/lima/shared_socket_vmnet.pid

--- a/install.sh
+++ b/install.sh
@@ -1,127 +1,230 @@
 #!/usr/bin/env bash
-# Unified installer for org
-# - Builds/pulls the container image if needed
-# - Installs a host-side launcher symlink
-# - Prints clear guidance when /usr/local/bin isn't writable
+# install.sh — smart, idempotent guest setup for `org`
+# - Installs system deps (curl, git, openssh-server, ufw, podman)
+# - Hardens firewall (deny IN/OUT; allow SSH IN; allow 127.0.0.1 OUT)
+# - Creates tmpfs scratch (~/scratch, noexec,nosuid,nodev)
+# - Ensures a real `org` command on PATH (no "bun run")
+# - Builds the Debian container image (auto when Containerfile exists)
+#
+# Flags:
+#   --no-sudo            user-only mode (skip system changes)
+#   --sudo               force sudo mode (prompt if needed)
+#   --no-harden          skip firewall + scratch
+#   --egress-https       keep 443/tcp open after install (for pulls)
+#   --build-image        force image build
+#   --skip-image         skip image build
+#   --image-tag TAG      tag for podman build (default: org:debian12)
+#   --containerfile F    path to Containerfile (default: ./Containerfile)
+#   --context DIR        podman build context (default: repo root)
+#
+# Env overrides:
+#   ORG_INSTALL_SUDO=auto|yes|no   (default auto)
+#   ORG_INSTALL_HARDEN=yes|no      (default yes)
+#   ORG_SCRATCH_SIZE=1G
+#   ORG_BUILD_IMAGE=auto|yes|no    (default auto → build if Containerfile exists)
+#   ORG_IMAGE_TAG=org:debian12
+#   ORG_CONTAINERFILE=Containerfile
+#   ORG_BUILD_CONTEXT=<repo root>
+#   ORG_KEEP_HTTPS=yes|no          (default no) leave 443 open after build
+#   ORG_APP_ENTRY=src/app.ts       (fallback entry if package.json has no bin)
+
 set -Eeuo pipefail
 
-show_help() {
-  cat <<'EOF'
-usage: ./org/launcher/install.sh [--engine podman|docker] [--image NAME[:TAG]] [--file Containerfile] [--rebuild]
+# --- enter repo root regardless of where we were invoked from ---
+# Resolve this script (follows symlinks; works on macOS/Linux)
+_self="${BASH_SOURCE[0]:-$0}"
+while [ -L "$_self" ]; do
+  target="$(readlink "$_self")"
+  case "$target" in
+    /*) _self="$target" ;;
+    *)  _self="$(dirname "$_self")/$target" ;;
+  esac
+done
+REPO_ROOT="$(cd "$(dirname "$_self")" && pwd)"
 
-Options:
-  --engine   Override container engine detection (podman|docker).
-  --image    Image name to build/use. Default: localhost/org-build:debian-12
-  --file     Containerfile/Dockerfile to build. Default: Containerfile
-  --rebuild  Force a rebuild of the image even if it already exists.
-EOF
-}
+# Temporarily switch into the repo; restore on exit
+pushd "$REPO_ROOT" >/dev/null
+trap 'popd >/dev/null' EXIT
+# --- end repo root switch ---
 
-ENGINE=""
-IMAGE=""
-FILE=""
-REBUILD=0
+USE_SUDO="${ORG_INSTALL_SUDO:-auto}"
+DO_HARDEN="${ORG_INSTALL_HARDEN:-yes}"
+SCRATCH_SIZE="${ORG_SCRATCH_SIZE:-1G}"
+BUILD_IMAGE="${ORG_BUILD_IMAGE:-auto}"
+IMAGE_TAG="${ORG_IMAGE_TAG:-org:debian12}"
+CONTAINERFILE="${ORG_CONTAINERFILE:-Containerfile}"
+BUILD_CONTEXT="${ORG_BUILD_CONTEXT:-$REPO_ROOT}"
+KEEP_HTTPS="${ORG_KEEP_HTTPS:-no}"
 
-while [ $# -gt 0 ]; do
+while [[ $# -gt 0 ]]; do
   case "$1" in
-    --engine) ENGINE="$2"; shift 2;;
-    --image)  IMAGE="$2"; shift 2;;
-    --file)   FILE="$2"; shift 2;;
-    --rebuild) REBUILD=1; shift;;
-    -h|--help) show_help; exit 0;;
-    --) shift; break;;
-    *) echo "[install][warn] ignoring unknown arg: $1" >&2; shift;;
+    --no-sudo)        USE_SUDO="no"; shift;;
+    --sudo)           USE_SUDO="yes"; shift;;
+    --no-harden)      DO_HARDEN="no"; shift;;
+    --egress-https)   KEEP_HTTPS="yes"; shift;;
+    --build-image)    BUILD_IMAGE="yes"; shift;;
+    --skip-image)     BUILD_IMAGE="no"; shift;;
+    --image-tag)      IMAGE_TAG="$2"; shift 2;;
+    --containerfile)  CONTAINERFILE="$2"; shift 2;;
+    --context)        BUILD_CONTEXT="$2"; shift 2;;
+    *) echo "Unknown flag: $1" >&2; exit 2;;
   esac
 done
 
-# ---------------------------
-# Detect container engine
-# ---------------------------
-if [ -n "$ENGINE" ]; then
-  true
-elif command -v podman >/dev/null 2>&1; then
-  ENGINE="${ORG_ENGINE:-podman}"
-elif command -v docker >/dev/null 2>&1; then
-  ENGINE="${ORG_ENGINE:-docker}"
-else
-  echo "[install][error] neither podman nor docker found in PATH." >&2
-  exit 127
-fi
+say()  { printf "\033[1;36m==>\033[0m %s\n" "$*"; }
+warn() { printf "\033[1;33m!!\033[0m %s\n" "$*" >&2; }
+die()  { printf "\033[1;31mxx\033[0m %s\n" "$*" >&2; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+am_root() { [[ "${EUID:-$(id -u)}" -eq 0 ]]; }
 
-# ---------------------------
-# Image + build file
-# ---------------------------
-IMAGE="${IMAGE:-${ORG_IMAGE:-localhost/org-build:debian-12}}"
-FILE="${FILE:-${ORG_CONTAINERFILE:-Containerfile}}"
+SUDO=""
+want_sudo() {
+  case "$USE_SUDO" in
+    yes)  return 0;;
+    no)   return 1;;
+    auto) am_root && return 0
+          have sudo && (sudo -n true 2>/dev/null || sudo -v) && return 0
+          return 1;;
+  esac
+}
+enable_sudo() { if want_sudo; then SUDO="sudo"; am_root && SUDO=""; fi; }
 
-echo "[install] engine = $ENGINE"
-echo "[install] image  = $IMAGE"
-echo "[install] file   = $FILE"
-
-# ---------------------------
-# Build image (respects --rebuild)
-# ---------------------------
-need_build=1
-if "$ENGINE" image inspect "$IMAGE" >/dev/null 2>&1; then
-  if [ "$REBUILD" -eq 1 ]; then
-    echo "[install] --rebuild given -> rebuilding image"
+apt_install() {
+  $SUDO env DEBIAN_FRONTEND=noninteractive apt-get update -y
+  $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "$@"
+}
+ensure_service() {
+  local svc="$1"
+  if $SUDO systemctl is-enabled --quiet "$svc" 2>/dev/null; then
+    $SUDO systemctl restart "$svc" || true
   else
-    need_build=0
+    $SUDO systemctl enable --now "$svc" || true
   fi
+}
+
+# ---------- 1) privilege / bun ----------
+say "Detecting privilege mode"
+enable_sudo || warn "No sudo available; proceeding user-only"
+
+if ! have bun; then
+  say "Installing Bun (user)"
+  curl -fsSL https://bun.sh/install | bash
+fi
+if ! echo ":$PATH:" | grep -q ":$HOME/.bun/bin:"; then
+  echo 'export BUN_INSTALL="$HOME/.bun"' >> "$HOME/.bashrc"
+  echo 'export PATH="$BUN_INSTALL/bin:$PATH"' >> "$HOME/.bashrc"
+  export BUN_INSTALL="$HOME/.bun"
+  export PATH="$BUN_INSTALL/bin:$PATH"
 fi
 
-if [ "$need_build" -eq 1 ]; then
-  echo "[install] building image (this can take a while)..."
-  "$ENGINE" build -t "$IMAGE" -f "$FILE" .
-  echo "[install] done. image built"
-else
-  echo "[install] image already present; skipping build"
+# ---------- 2) system deps (sudo path) ----------
+if want_sudo; then
+  say "Installing system packages (curl git openssh-server ufw podman)"
+  apt_install curl git openssh-server ufw podman uidmap slirp4netns sudo ca-certificates
+  say "Enabling sshd"
+  ensure_service ssh
 fi
 
-# ---------------------------
-# Host launcher symlink
-# ---------------------------
-REPO_DIR="$(pwd)"
-SRC="$REPO_DIR/org"
+# ---------- 3) harden box (after deps so we don't break apt) ----------
+if [[ "$DO_HARDEN" == "yes" ]] && want_sudo; then
+  say "Applying firewall policy (deny IN/OUT; allow SSH IN; allow 127.0.0.1 OUT)"
+  $SUDO ufw allow 22/tcp >/dev/null 2>&1 || true
+  $SUDO ufw default deny incoming  >/dev/null 2>&1 || true
+  $SUDO ufw default deny outgoing  >/dev/null 2>&1 || true
+  $SUDO ufw allow out to 127.0.0.1 >/dev/null 2>&1 || true
+  [[ "$KEEP_HTTPS" == "yes" ]] && $SUDO ufw allow out 443/tcp >/dev/null 2>&1 || true
+  $SUDO ufw --force enable >/dev/null 2>&1 || true
 
-if [ ! -x "$SRC" ]; then
-  echo "[install][error] launcher not found or not executable at: $SRC" >&2
-  echo "  Make sure you're running this from the repo root where 'org' lives." >&2
-  exit 66
+  say "Creating tmpfs scratch at ~/scratch (${SCRATCH_SIZE}, noexec,nosuid,nodev)"
+  SCRATCH_DIR="$HOME/scratch"
+  $SUDO mkdir -p "$SCRATCH_DIR"
+  FSTAB_LINE="tmpfs $SCRATCH_DIR tmpfs rw,noexec,nosuid,nodev,mode=700,size=${SCRATCH_SIZE} 0 0"
+  if ! grep -qs "^[^#].*[[:space:]]$SCRATCH_DIR[[:space:]]" /etc/fstab; then
+    echo "$FSTAB_LINE" | $SUDO tee -a /etc/fstab >/dev/null
+  else
+    $SUDO sed -i "s#^[^#].*[[:space:]]$SCRATCH_DIR[[:space:]].*\$#$FSTAB_LINE#" /etc/fstab
+  fi
+  $SUDO mount -o remount "$SCRATCH_DIR" 2>/dev/null || $SUDO mount "$SCRATCH_DIR" || true
 fi
 
-# Prefer a system-wide link, then gracefully fall back to user bin on permission error.
-if ln -sf "$SRC" /usr/local/bin/org 2>/dev/null; then
-  echo "[install] installed: /usr/local/bin/org -> $SRC"
-else
-  echo "[install][warn] cannot write /usr/local/bin (no sudo?)."
-  echo "[install] installing to user bin: ~/.local/bin"
+# ---------- 4) project deps & real `org` ----------
+say "Installing project deps (bun install)"
+bun install
+say "Optional build (if present)"
+bun run build || true
 
+say "Exposing 'org' command (prefer package.json bin via bun global)"
+bun install -g . || true
+if ! command -v org >/dev/null 2>&1; then
   mkdir -p "$HOME/.local/bin"
-  ln -sf "$SRC" "$HOME/.local/bin/org"
-  echo "[install] installed: $HOME/.local/bin/org -> $SRC"
-
-  # Reassure user + how to use immediately
-  if ! command -v org >/dev/null 2>&1; then
-    echo
-    echo "[install][hint] Your shell may not have \$HOME/.local/bin on PATH yet."
-    echo "  For this shell session, run:"
-    echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
-    echo
-    echo "  To make it persistent, add that line to your shell RC (e.g. ~/.bashrc or ~/.zshrc)."
+  WRAP="$HOME/.local/bin/org"
+  APP_ENTRY="${ORG_APP_ENTRY:-$REPO_ROOT/src/app.ts}"
+  cat >"$WRAP" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+exec bun "$APP_ENTRY" "\$@"
+EOF
+  chmod +x "$WRAP"
+  if ! echo ":$PATH:" | grep -q ":$HOME/.local/bin:"; then
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+    export PATH="$HOME/.local/bin:$PATH"
   fi
-
-  echo
-  echo "[install] If you prefer a system-wide link later, run:"
-  echo "  sudo ln -sf \"$SRC\" \"/usr/local/bin/org\""
 fi
 
-# ---------------------------
-# Final friendly nudge
-# ---------------------------
-echo
-echo "[install] Try:"
-echo "  org --ui console --prompt 'say hi'"
-echo "  org --ui tmux   --prompt 'say hi'"
-echo
-echo "[install] done. installation complete"
+# ---------- 5) build container image (smart) ----------
+should_build_image() {
+  case "$BUILD_IMAGE" in
+    yes) return 0;;
+    no)  return 1;;
+    auto)
+      [[ -f "$CONTAINERFILE" ]] && return 0
+      return 1;;
+  esac
+}
+
+if should_build_image; then
+  say "Preparing Podman (rootless)"
+  podman info >/dev/null 2>&1 || podman system migrate -f || true
+
+  # If hardened, temporarily open DNS + HTTPS for pulls
+  OPENED=()
+  if [[ "$DO_HARDEN" == "yes" ]] && want_sudo; then
+    for rule in "53/udp" "53/tcp" "443/tcp"; do
+      if ! $SUDO ufw status | grep -q "$rule.*ALLOW OUT"; then
+        say "Temporarily allowing outbound $rule for image pulls"
+        $SUDO ufw allow out "$rule" >/dev/null 2>&1 || true
+        OPENED+=("$rule")
+      fi
+    done
+  fi
+
+  say "Building container image: tag=${IMAGE_TAG}, file=${CONTAINERFILE}, context=${BUILD_CONTEXT}"
+  if [[ ! -f "$CONTAINERFILE" ]]; then
+    warn "Containerfile '${CONTAINERFILE}' not found; skipping build."
+  else
+    podman build --pull=always -t "$IMAGE_TAG" -f "$CONTAINERFILE" "$BUILD_CONTEXT"
+  fi
+
+  # Close temporary egress unless user wants https kept open
+  if [[ "$DO_HARDEN" == "yes" ]] && want_sudo; then
+    for rule in "${OPENED[@]}"; do
+      [[ "$KEEP_HTTPS" == "yes" && "$rule" == "443/tcp" ]] && continue
+      say "Closing temporary $rule egress"
+      $SUDO ufw delete allow out "$rule" >/dev/null 2>&1 || true
+    done
+  fi
+else
+  say "Skipping image build (mode: $BUILD_IMAGE)"
+fi
+
+# ---------- 6) summary ----------
+say "Ready."
+if command -v org >/dev/null 2>&1; then
+  say "Try:  org --ui console     (or: org --ui tmux)"
+else
+  warn "Add PATH for this session:  export PATH=\"$HOME/.bun/bin:$HOME/.local/bin:\$PATH\""
+fi
+if [[ "$DO_HARDEN" == "yes" ]] && want_sudo; then
+  say "Firewall:"
+  $SUDO ufw status verbose || true
+fi

--- a/install.sh
+++ b/install.sh
@@ -1,60 +1,37 @@
 #!/usr/bin/env bash
 # install.sh — smart, idempotent guest setup for `org`
-# - Installs system deps (curl, git, openssh-server, ufw, podman)
-# - Hardens firewall (deny IN/OUT; allow SSH IN; allow 127.0.0.1 OUT)
-# - Creates tmpfs scratch (~/scratch, noexec,nosuid,nodev)
-# - Ensures a real `org` command on PATH (no "bun run")
-# - Builds the Debian container image (auto when Containerfile exists)
-#
-# Flags:
-#   --no-sudo            user-only mode (skip system changes)
-#   --sudo               force sudo mode (prompt if needed)
-#   --no-harden          skip firewall + scratch
-#   --egress-https       keep 443/tcp open after install (for pulls)
-#   --build-image        force image build
-#   --skip-image         skip image build
-#   --image-tag TAG      tag for podman build (default: org:debian12)
-#   --containerfile F    path to Containerfile (default: ./Containerfile)
-#   --context DIR        podman build context (default: repo root)
-#
-# Env overrides:
-#   ORG_INSTALL_SUDO=auto|yes|no   (default auto)
-#   ORG_INSTALL_HARDEN=yes|no      (default yes)
-#   ORG_SCRATCH_SIZE=1G
-#   ORG_BUILD_IMAGE=auto|yes|no    (default auto → build if Containerfile exists)
-#   ORG_IMAGE_TAG=org:debian12
-#   ORG_CONTAINERFILE=Containerfile
-#   ORG_BUILD_CONTEXT=<repo root>
-#   ORG_KEEP_HTTPS=yes|no          (default no) leave 443 open after build
-#   ORG_APP_ENTRY=src/app.ts       (fallback entry if package.json has no bin)
+# MIT License
 
 set -Eeuo pipefail
 
-# --- enter repo root regardless of where we were invoked from ---
-# Resolve this script (follows symlinks; works on macOS/Linux)
+# --- enter repo root regardless of where invoked ---
 _self="${BASH_SOURCE[0]:-$0}"
 while [ -L "$_self" ]; do
-  target="$(readlink "$_self")"
-  case "$target" in
-    /*) _self="$target" ;;
-    *)  _self="$(dirname "$_self")/$target" ;;
-  esac
+  t="$(readlink "$_self")"; case "$t" in /*) _self="$t";; *) _self="$(dirname "$_self")/$t";; esac
 done
 REPO_ROOT="$(cd "$(dirname "$_self")" && pwd)"
-
-# Temporarily switch into the repo; restore on exit
 pushd "$REPO_ROOT" >/dev/null
 trap 'popd >/dev/null' EXIT
-# --- end repo root switch ---
+# ---------------------------------------------------
 
-USE_SUDO="${ORG_INSTALL_SUDO:-auto}"
-DO_HARDEN="${ORG_INSTALL_HARDEN:-yes}"
+say()  { printf "\033[1;36m==>\033[0m %s\n" "$*"; }
+warn() { printf "\033[1;33m!!\033[0m %s\n" "$*" >&2; }
+die()  { printf "\033[1;31mxx\033[0m %s\n" "$*" >&2; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+am_root(){ [[ "${EUID:-$(id -u)}" -eq 0 ]]; }
+
+# ---------- defaults & flags ----------
+USE_SUDO="${ORG_INSTALL_SUDO:-auto}"        # auto|yes|no
+DO_HARDEN="${ORG_INSTALL_HARDEN:-yes}"      # yes|no
 SCRATCH_SIZE="${ORG_SCRATCH_SIZE:-1G}"
-BUILD_IMAGE="${ORG_BUILD_IMAGE:-auto}"
+BUILD_IMAGE="${ORG_BUILD_IMAGE:-auto}"      # auto builds if Containerfile exists
 IMAGE_TAG="${ORG_IMAGE_TAG:-org:debian12}"
 CONTAINERFILE="${ORG_CONTAINERFILE:-Containerfile}"
 BUILD_CONTEXT="${ORG_BUILD_CONTEXT:-$REPO_ROOT}"
 KEEP_HTTPS="${ORG_KEEP_HTTPS:-no}"
+
+LAUNCH="${ORG_INSTALL_LAUNCH:-auto}"        # auto|yes|no
+UI="${ORG_INSTALL_UI:-console}"             # console|tmux
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -67,67 +44,51 @@ while [[ $# -gt 0 ]]; do
     --image-tag)      IMAGE_TAG="$2"; shift 2;;
     --containerfile)  CONTAINERFILE="$2"; shift 2;;
     --context)        BUILD_CONTEXT="$2"; shift 2;;
-    *) echo "Unknown flag: $1" >&2; exit 2;;
+    --launch)         LAUNCH="yes"; shift;;
+    --no-launch)      LAUNCH="no"; shift;;
+    --ui)             UI="$2"; shift 2;;
+    *) die "Unknown flag: $1";;
   esac
 done
-
-say()  { printf "\033[1;36m==>\033[0m %s\n" "$*"; }
-warn() { printf "\033[1;33m!!\033[0m %s\n" "$*" >&2; }
-die()  { printf "\033[1;31mxx\033[0m %s\n" "$*" >&2; exit 1; }
-have() { command -v "$1" >/dev/null 2>&1; }
-am_root() { [[ "${EUID:-$(id -u)}" -eq 0 ]]; }
 
 SUDO=""
 want_sudo() {
   case "$USE_SUDO" in
-    yes)  return 0;;
-    no)   return 1;;
-    auto) am_root && return 0
-          have sudo && (sudo -n true 2>/dev/null || sudo -v) && return 0
-          return 1;;
+    yes) return 0;;
+    no)  return 1;;
+    auto)
+      am_root && return 0
+      have sudo && (sudo -n true 2>/dev/null || sudo -v) && return 0
+      return 1;;
   esac
 }
-enable_sudo() { if want_sudo; then SUDO="sudo"; am_root && SUDO=""; fi; }
+enable_sudo(){ if want_sudo; then SUDO="sudo"; am_root && SUDO=""; fi; }
 
 apt_install() {
   $SUDO env DEBIAN_FRONTEND=noninteractive apt-get update -y
   $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "$@"
 }
-ensure_service() {
-  local svc="$1"
-  if $SUDO systemctl is-enabled --quiet "$svc" 2>/dev/null; then
-    $SUDO systemctl restart "$svc" || true
-  else
-    $SUDO systemctl enable --now "$svc" || true
-  fi
-}
+ensure_service(){ local s="$1"; $SUDO systemctl enable --now "$s" >/dev/null 2>&1 || $SUDO systemctl restart "$s" >/dev/null 2>&1 || true; }
 
-# ---------- 1) privilege / bun ----------
-say "Detecting privilege mode"
-enable_sudo || warn "No sudo available; proceeding user-only"
-
-if ! have bun; then
-  say "Installing Bun (user)"
-  curl -fsSL https://bun.sh/install | bash
-fi
+# ---------- 1) privilege & Bun ----------
+say "Detecting privilege mode"; enable_sudo || warn "No sudo; proceeding user-only (no system changes)"
+if ! have bun; then say "Installing Bun (user)"; curl -fsSL https://bun.sh/install | bash; fi
 if ! echo ":$PATH:" | grep -q ":$HOME/.bun/bin:"; then
   echo 'export BUN_INSTALL="$HOME/.bun"' >> "$HOME/.bashrc"
   echo 'export PATH="$BUN_INSTALL/bin:$PATH"' >> "$HOME/.bashrc"
-  export BUN_INSTALL="$HOME/.bun"
-  export PATH="$BUN_INSTALL/bin:$PATH"
+  export BUN_INSTALL="$HOME/.bun"; export PATH="$BUN_INSTALL/bin:$PATH"
 fi
 
-# ---------- 2) system deps (sudo path) ----------
+# ---------- 2) system deps ----------
 if want_sudo; then
   say "Installing system packages (curl git openssh-server ufw podman)"
-  apt_install curl git openssh-server ufw podman uidmap slirp4netns sudo ca-certificates
-  say "Enabling sshd"
-  ensure_service ssh
+  apt_install curl git openssh-server ufw podman uidmap slirp4netns ca-certificates sudo
+  say "Ensuring sshd is enabled"; ensure_service ssh
 fi
 
-# ---------- 3) harden box (after deps so we don't break apt) ----------
+# ---------- 3) harden (UFW + tmpfs scratch) ----------
 if [[ "$DO_HARDEN" == "yes" ]] && want_sudo; then
-  say "Applying firewall policy (deny IN/OUT; allow SSH IN; allow 127.0.0.1 OUT)"
+  say "Applying firewall (deny IN/OUT; allow SSH IN; allow 127.0.0.1 OUT)"
   $SUDO ufw allow 22/tcp >/dev/null 2>&1 || true
   $SUDO ufw default deny incoming  >/dev/null 2>&1 || true
   $SUDO ufw default deny outgoing  >/dev/null 2>&1 || true
@@ -135,36 +96,32 @@ if [[ "$DO_HARDEN" == "yes" ]] && want_sudo; then
   [[ "$KEEP_HTTPS" == "yes" ]] && $SUDO ufw allow out 443/tcp >/dev/null 2>&1 || true
   $SUDO ufw --force enable >/dev/null 2>&1 || true
 
-  say "Creating tmpfs scratch at ~/scratch (${SCRATCH_SIZE}, noexec,nosuid,nodev)"
-  SCRATCH_DIR="$HOME/scratch"
-  $SUDO mkdir -p "$SCRATCH_DIR"
-  FSTAB_LINE="tmpfs $SCRATCH_DIR tmpfs rw,noexec,nosuid,nodev,mode=700,size=${SCRATCH_SIZE} 0 0"
-  if ! grep -qs "^[^#].*[[:space:]]$SCRATCH_DIR[[:space:]]" /etc/fstab; then
+  say "Creating tmpfs scratch at ~/scratch ($SCRATCH_SIZE, noexec,nosuid,nodev)"
+  SCRATCH="$HOME/scratch"
+  $SUDO mkdir -p "$SCRATCH"
+  FSTAB_LINE="tmpfs $SCRATCH tmpfs rw,noexec,nosuid,nodev,mode=700,size=${SCRATCH_SIZE} 0 0"
+  if ! grep -qs "^[^#].*[[:space:]]$SCRATCH[[:space:]]" /etc/fstab; then
     echo "$FSTAB_LINE" | $SUDO tee -a /etc/fstab >/dev/null
   else
-    $SUDO sed -i "s#^[^#].*[[:space:]]$SCRATCH_DIR[[:space:]].*\$#$FSTAB_LINE#" /etc/fstab
+    $SUDO sed -i "s#^[^#].*[[:space:]]$SCRATCH[[:space:]].*\$#$FSTAB_LINE#" /etc/fstab
   fi
-  $SUDO mount -o remount "$SCRATCH_DIR" 2>/dev/null || $SUDO mount "$SCRATCH_DIR" || true
+  $SUDO mount -o remount "$SCRATCH" 2>/dev/null || $SUDO mount "$SCRATCH" || true
 fi
 
 # ---------- 4) project deps & real `org` ----------
-say "Installing project deps (bun install)"
-bun install
-say "Optional build (if present)"
-bun run build || true
-
-say "Exposing 'org' command (prefer package.json bin via bun global)"
+say "Installing project deps (bun install)"; bun install
+say "Optional build (if present)"; bun run build || true
+say "Exposing 'org' command (prefer package.json bin via Bun global)"
 bun install -g . || true
 if ! command -v org >/dev/null 2>&1; then
   mkdir -p "$HOME/.local/bin"
-  WRAP="$HOME/.local/bin/org"
   APP_ENTRY="${ORG_APP_ENTRY:-$REPO_ROOT/src/app.ts}"
-  cat >"$WRAP" <<EOF
+  cat >"$HOME/.local/bin/org" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 exec bun "$APP_ENTRY" "\$@"
 EOF
-  chmod +x "$WRAP"
+  chmod +x "$HOME/.local/bin/org"
   if ! echo ":$PATH:" | grep -q ":$HOME/.local/bin:"; then
     echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
     export PATH="$HOME/.local/bin:$PATH"
@@ -173,58 +130,52 @@ fi
 
 # ---------- 5) build container image (smart) ----------
 should_build_image() {
-  case "$BUILD_IMAGE" in
-    yes) return 0;;
-    no)  return 1;;
-    auto)
-      [[ -f "$CONTAINERFILE" ]] && return 0
-      return 1;;
-  esac
+  case "$BUILD_IMAGE" in yes) return 0;; no) return 1;; auto) [[ -f "$CONTAINERFILE" ]];; esac
 }
-
 if should_build_image; then
-  say "Preparing Podman (rootless)"
-  podman info >/dev/null 2>&1 || podman system migrate -f || true
-
-  # If hardened, temporarily open DNS + HTTPS for pulls
+  say "Preparing Podman (rootless)"; podman info >/dev/null 2>&1 || podman system migrate -f || true
   OPENED=()
   if [[ "$DO_HARDEN" == "yes" ]] && want_sudo; then
     for rule in "53/udp" "53/tcp" "443/tcp"; do
       if ! $SUDO ufw status | grep -q "$rule.*ALLOW OUT"; then
         say "Temporarily allowing outbound $rule for image pulls"
-        $SUDO ufw allow out "$rule" >/dev/null 2>&1 || true
-        OPENED+=("$rule")
+        $SUDO ufw allow out "$rule" >/dev/null 2>&1 || true; OPENED+=("$rule")
       fi
     done
   fi
-
-  say "Building container image: tag=${IMAGE_TAG}, file=${CONTAINERFILE}, context=${BUILD_CONTEXT}"
-  if [[ ! -f "$CONTAINERFILE" ]]; then
-    warn "Containerfile '${CONTAINERFILE}' not found; skipping build."
-  else
+  say "Building container image (tag=$IMAGE_TAG, file=$CONTAINERFILE)"
+  if [[ -f "$CONTAINERFILE" ]]; then
     podman build --pull=always -t "$IMAGE_TAG" -f "$CONTAINERFILE" "$BUILD_CONTEXT"
+  else
+    warn "Containerfile '$CONTAINERFILE' not found; skipping build."
   fi
-
-  # Close temporary egress unless user wants https kept open
   if [[ "$DO_HARDEN" == "yes" ]] && want_sudo; then
     for rule in "${OPENED[@]}"; do
       [[ "$KEEP_HTTPS" == "yes" && "$rule" == "443/tcp" ]] && continue
-      say "Closing temporary $rule egress"
-      $SUDO ufw delete allow out "$rule" >/dev/null 2>&1 || true
+      say "Closing temporary $rule egress"; $SUDO ufw delete allow out "$rule" >/dev/null 2>&1 || true
     done
   fi
 else
-  say "Skipping image build (mode: $BUILD_IMAGE)"
+  say "Skipping image build (mode=$BUILD_IMAGE)"
 fi
 
-# ---------- 6) summary ----------
+# ---------- 6) maybe launch ----------
+maybe_launch_org() {
+  command -v org >/dev/null 2>&1 || { warn "'org' not on PATH yet"; return 0; }
+  [[ "$UI" == "tmux" ]] && command -v tmux >/dev/null 2>&1 || UI="console"
+  is_tty=0; [[ -t 0 && -t 1 ]] && is_tty=1
+  case "$LAUNCH" in
+    yes) say "Launching org (--ui $UI)…"; exec org --ui "$UI" ;;
+    no)  say "Install finished. Run:  org --ui $UI" ;;
+    auto)
+      if [[ "$is_tty" -eq 1 ]]; then
+        read -r -p "$(printf 'Launch org now (--ui %s)? [Y/n] ' "$UI")" ans; ans=${ans:-Y}
+        [[ "$ans" =~ ^[Yy]$ ]] && { say "Launching org…"; exec org --ui "$UI"; } || say "Skipping launch."
+      else
+        say "Install finished. Run:  org --ui $UI"
+      fi
+      ;;
+  esac
+}
 say "Ready."
-if command -v org >/dev/null 2>&1; then
-  say "Try:  org --ui console     (or: org --ui tmux)"
-else
-  warn "Add PATH for this session:  export PATH=\"$HOME/.bun/bin:$HOME/.local/bin:\$PATH\""
-fi
-if [[ "$DO_HARDEN" == "yes" ]] && want_sudo; then
-  say "Firewall:"
-  $SUDO ufw status verbose || true
-fi
+maybe_launch_org

--- a/orgctl
+++ b/orgctl
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # orgctl - MIT License
 # Unified orchestration CLI for org
-# - Apple Silicon (arm64): Lima backend (Lima 1.2.x compatible)
+# - Apple Silicon (arm64): Lima backend (Lima 1.2.x compatible; no --detach/--user needed)
 # - Intel (x86_64): VirtualBox backend
 # Lima config search order:
 #   1) $ORG_LIMA_CONFIG
@@ -10,13 +10,14 @@
 #   4) $ORG_DIR/.org/config/org.lima.yaml
 
 set -euo pipefail
-VERSION="0.6.2"
+VERSION="0.6.3"
 
 ORG_DIR="$(cd "$(dirname "$0")" && pwd)"
 VM_NAME="org-vm"
 HOST_SSH_PORT="${HOST_SSH_PORT:-2222}"
-SSH_USER="$(whoami)"   # Lima 1.2.x mirrors host username
+SSH_USER="$(whoami)"   # Lima mirrors host username on 1.2.x
 
+# ---------- helpers ----------
 backend() {
   local arch sys
   arch="$(uname -m)"; sys="$(uname -s)"
@@ -32,18 +33,25 @@ need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2;
 ssh_base() { echo "-p" "$HOST_SSH_PORT" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null"; }
 
 lima_config_path() {
-  local cands=()
-  [[ -n "${ORG_LIMA_CONFIG:-}" ]] && cands+=("$ORG_LIMA_CONFIG")
-  cands+=("$PWD/.org/config/org.lima.yaml" "$HOME/.config/org/org.lima.yaml" "$ORG_DIR/.org/config/org.lima.yaml")
-  for p in "${cands[@]}"; do [[ -f "$p" ]] && { echo "$p"; return; }; done
+  local p
+  for p in \
+    "${ORG_LIMA_CONFIG:-}" \
+    "$PWD/.org/config/org.lima.yaml" \
+    "$HOME/.config/org/org.lima.yaml" \
+    "$ORG_DIR/.org/config/org.lima.yaml"
+  do
+    [[ -n "$p" && -f "$p" ]] && { echo "$p"; return; }
+  done
   cat >&2 <<'EOF'
 orgctl: could not find org.lima.yaml
+
 Searched:
   $ORG_LIMA_CONFIG
   $PWD/.org/config/org.lima.yaml
   $HOME/.config/org/org.lima.yaml
   $ORG_DIR/.org/config/org.lima.yaml
-Fix with:
+
+Fix:
   export ORG_LIMA_CONFIG="$PWD/.org/config/org.lima.yaml"
   # or
   mkdir -p ~/.config/org && ln -s "$PWD/.org/config/org.lima.yaml" ~/.config/org/org.lima.yaml
@@ -51,25 +59,50 @@ EOF
   exit 1
 }
 
-# ---------- Lima backend ----------
+# Lima 1.2.x compatibility helpers
+lima_has_flag() { limactl start -h 2>&1 | grep -q -- "$1"; }
 lima_exists() {
-  # robust for Lima 1.2.x: directory check; also try limactl list if present
   [[ -d "$HOME/.lima/org.lima" ]] && return 0
   limactl list 2>/dev/null | awk 'NR>1{print $1}' | grep -qx "org.lima" 2>/dev/null
 }
+lima_wait_ready() {
+  # Wait until a trivial command via guest agent succeeds (max ~3 min)
+  local i
+  for i in {1..90}; do
+    limactl shell org.lima -- true >/dev/null 2>&1 && return 0
+    sleep 2
+  done
+  echo "Timed out waiting for Lima guest to be ready." >&2
+  return 1
+}
+lima_start_detached() {
+  if lima_has_flag --detach; then
+    limactl start --name org.lima --detach || true
+  else
+    # Start in background and wait until shell works
+    nohup limactl start --name org.lima >/tmp/orgctl-lima-start.log 2>&1 &
+    lima_wait_ready
+  fi
+}
+
+# ---------- Lima backend ----------
 lima_vm_init() {
   need limactl
   if lima_exists; then
     echo "Lima instance org.lima already exists; starting it."
-    limactl start org.lima || true
+    lima_start_detached
   else
     local cfg; cfg="$(lima_config_path)"
     echo "Creating Lima VM with config: $cfg"
-    # Lima 1.2.x has no --detach; this will stream logs until boot completes
-    limactl start --name org.lima "$cfg"
+    if lima_has_flag --detach; then
+      limactl start --name org.lima --detach "$cfg"
+    else
+      nohup limactl start --name org.lima "$cfg" >/tmp/orgctl-lima-create.log 2>&1 &
+      lima_wait_ready
+    fi
   fi
 }
-lima_vm_up()      { need limactl; limactl start org.lima || true; }
+lima_vm_up()      { need limactl; lima_start_detached; }
 lima_vm_stop()    { need limactl; limactl stop org.lima || true; }
 lima_vm_destroy() { need limactl; limactl delete org.lima || true; }
 lima_vm_ssh()     { need limactl; limactl shell org.lima; }
@@ -104,7 +137,8 @@ build/
 .DS_Store
 EOF
   echo "Syncing current directory to /home/${SSH_USER}/org ..."
-  rsync -az --delete --progress --exclude-from="$tmp_excl" -e "ssh $(ssh_base | xargs echo)" ./ \
+  rsync -az --delete --progress --exclude-from="$tmp_excl" \
+    -e "ssh $(ssh_base | xargs echo)" ./ \
     "${SSH_USER}@127.0.0.1:/home/${SSH_USER}/org/"
   rm -f "$tmp_excl"
 }
@@ -126,6 +160,7 @@ tarball_install_in_vm() {
       curl -fsSL ${url@Q} -o /tmp/org.tgz && ${verify} \
       tar -xzf /tmp/org.tgz -C /home/${SSH_USER}/org --strip-components=1'"
 }
+
 cmd_app_install() {
   local FROM="host" REPO_URL="https://github.com/tjamescouch/org.git" TAR_URL="" TAR_SHA="" NO_RUN="no"
   while [[ $# -gt 0 ]]; do
@@ -147,6 +182,20 @@ cmd_app_install() {
   [[ "$NO_RUN" == "yes" ]] || run_install_script
 }
 
+# ---------- high-level UX ----------
+cmd_quickstart() {
+  if [[ "$(backend)" != "lima" ]]; then
+    echo "quickstart is for Apple Silicon (Lima). On Intel: brew install --cask virtualbox && orgctl vm init && orgctl vm ssh" >&2
+    exit 1
+  fi
+  # Validate we can resolve a Lima config first
+  local cfg; cfg="$(lima_config_path)"
+  echo "Using Lima config: $cfg"
+  lima_vm_init
+  lima_vm_ssh
+}
+
+# ---------- dispatcher ----------
 cmd_vm() {
   local sub="${1:-}"; shift || true
   case "$(backend)" in
@@ -180,9 +229,11 @@ usage() {
 orgctl v$VERSION
 
 USAGE:
+  orgctl quickstart                              # Apple Silicon: ensure VM up + open shell
   orgctl vm <init|up|stop|destroy|ssh|export>
   orgctl app install [--from host|git|tar] [--repo URL] [--tar-url URL --tar-sha256 SHA] [--no-run]
   orgctl version
+
 ENV:
   ORG_LIMA_CONFIG   Absolute path to org.lima.yaml (overrides search)
   HOST_SSH_PORT     SSH port to the guest (default 2222)
@@ -190,13 +241,14 @@ EOF
 }
 
 case "${1:-}" in
-  vm) shift; cmd_vm "$@" ;;
-  app) shift; sub="${1:-}"; shift || true
-       case "$sub" in
-         install) cmd_app_install "$@" ;;
-         *) usage; exit 1 ;;
-       esac ;;
-  version) echo "$VERSION" ;;
+  quickstart) shift; cmd_quickstart "$@" ;;
+  vm)         shift; cmd_vm "$@" ;;
+  app)        shift; sub="${1:-}"; shift || true
+              case "$sub" in
+                install) cmd_app_install "$@" ;;
+                *) usage; exit 1 ;;
+              esac ;;
+  version)    echo "$VERSION" ;;
   ""|help|-h|--help) usage ;;
-  *) usage; exit 1 ;;
+  *)          usage; exit 1 ;;
 esac

--- a/orgctl
+++ b/orgctl
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # orgctl - MIT License
-# Unified orchestration CLI for org
-# - Apple Silicon (arm64): Lima backend (Lima 1.2.x compatible; no --detach/--user needed)
+# v0.6.4
+# - Apple Silicon (arm64): Lima backend (Lima 1.2.x compatible; no --detach needed)
 # - Intel (x86_64): VirtualBox backend
 # Lima config search order:
 #   1) $ORG_LIMA_CONFIG
@@ -10,14 +10,13 @@
 #   4) $ORG_DIR/.org/config/org.lima.yaml
 
 set -euo pipefail
-VERSION="0.6.3"
+VERSION="0.6.4"
 
 ORG_DIR="$(cd "$(dirname "$0")" && pwd)"
 VM_NAME="org-vm"
 HOST_SSH_PORT="${HOST_SSH_PORT:-2222}"
-SSH_USER="$(whoami)"   # Lima mirrors host username on 1.2.x
+SSH_USER="$(whoami)"   # Lima 1.2.x mirrors host username
 
-# ---------- helpers ----------
 backend() {
   local arch sys
   arch="$(uname -m)"; sys="$(uname -s)"
@@ -32,6 +31,7 @@ backend() {
 need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }; }
 ssh_base() { echo "-p" "$HOST_SSH_PORT" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null"; }
 
+# ---- find Lima YAML ----
 lima_config_path() {
   local p
   for p in \
@@ -59,45 +59,71 @@ EOF
   exit 1
 }
 
-# Lima 1.2.x compatibility helpers
+# ---- Lima helpers (1.2.x safe) ----
 lima_has_flag() { limactl start -h 2>&1 | grep -q -- "$1"; }
 lima_exists() {
   [[ -d "$HOME/.lima/org.lima" ]] && return 0
   limactl list 2>/dev/null | awk 'NR>1{print $1}' | grep -qx "org.lima" 2>/dev/null
 }
+ensure_socket_vmnet_if_needed() {
+  # If YAML requests networking, require socket_vmnet running (Darwin only)
+  local cfg="$1"
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    if grep -qE '^[[:space:]]*networks:' "$cfg"; then
+      if ! pgrep -f '/opt/homebrew/.*/socket_vmnet(/socket_vmnet)?' >/dev/null 2>&1 \
+         && ! pgrep -f 'socket_vmnet' >/dev/null 2>&1; then
+        cat >&2 <<'EOF'
+orgctl: Lima networking helper 'socket_vmnet' is not running.
+Run:
+  brew install socket_vmnet
+  sudo brew services start socket_vmnet
+Then re-run: orgctl quickstart
+EOF
+        exit 1
+      fi
+    fi
+  fi
+}
 lima_wait_ready() {
-  # Wait until a trivial command via guest agent succeeds (max ~3 min)
-  local i
-  for i in {1..90}; do
-    limactl shell org.lima -- true >/dev/null 2>&1 && return 0
-    sleep 2
+  # Print a spinner/progress while waiting for guest agent
+  local i=0 spin='|/-\'
+  printf "Waiting for VM to become ready "
+  while (( i < 120 )); do  # ~4 minutes
+    if limactl shell org.lima -- true >/dev/null 2>&1; then
+      printf "\r%-70s\r" ""  # clear line
+      return 0
+    fi
+    printf "\rWaiting for VM to become ready %c" "${spin:i%4:1}"
+    sleep 2; ((i++))
   done
-  echo "Timed out waiting for Lima guest to be ready." >&2
+  printf "\n"
+  echo "Timed out waiting for Lima guest. See logs:" >&2
+  echo "  tail -f ~/.lima/org.lima/serial*.log" >&2
   return 1
 }
 lima_start_detached() {
   if lima_has_flag --detach; then
     limactl start --name org.lima --detach || true
   else
-    # Start in background and wait until shell works
-    nohup limactl start --name org.lima >/tmp/orgctl-lima-start.log 2>&1 &
+    nohup limactl start --name org.lima >/tmp/orgctl-lima-start.log 2>&1 < /dev/null &
     lima_wait_ready
   fi
 }
 
-# ---------- Lima backend ----------
+# ---- Lima backend ----
 lima_vm_init() {
   need limactl
+  local cfg
   if lima_exists; then
     echo "Lima instance org.lima already exists; starting it."
     lima_start_detached
   else
-    local cfg; cfg="$(lima_config_path)"
+    cfg="$(lima_config_path)"; ensure_socket_vmnet_if_needed "$cfg"
     echo "Creating Lima VM with config: $cfg"
     if lima_has_flag --detach; then
       limactl start --name org.lima --detach "$cfg"
     else
-      nohup limactl start --name org.lima "$cfg" >/tmp/orgctl-lima-create.log 2>&1 &
+      nohup limactl start --name org.lima "$cfg" >/tmp/orgctl-lima-create.log 2>&1 < /dev/null &
       lima_wait_ready
     fi
   fi
@@ -108,22 +134,16 @@ lima_vm_destroy() { need limactl; limactl delete org.lima || true; }
 lima_vm_ssh()     { need limactl; limactl shell org.lima; }
 lima_vm_export()  { echo "Export not supported for Lima"; }
 
-# ---------- VirtualBox backend ----------
+# ---- VirtualBox backend (kept minimal) ----
 assert_virtualbox() { need VBoxManage; }
-vbox_vm_init() {
-  assert_virtualbox
-  if VBoxManage list vms | grep -q "\"$VM_NAME\""; then
-    echo "VM already exists: $VM_NAME"; exit 1
-  fi
-  echo "TODO: implement full VBox unattended install"
-}
+vbox_vm_init() { assert_virtualbox; echo "TODO: implement VBox unattended install"; }
 vbox_vm_up()      { assert_virtualbox; VBoxManage startvm "$VM_NAME" --type headless; }
 vbox_vm_stop()    { assert_virtualbox; VBoxManage controlvm "$VM_NAME" acpipowerbutton || true; }
 vbox_vm_destroy() { assert_virtualbox; VBoxManage unregistervm "$VM_NAME" --delete || true; }
 vbox_vm_ssh()     { ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1"; }
 vbox_vm_export()  { assert_virtualbox; VBoxManage export "$VM_NAME" --output "$VM_NAME.ova"; }
 
-# ---------- App install (common) ----------
+# ---- App install (shared) ----
 looks_like_org_repo() { [[ -f "package.json" || -f "bun.toml" || -f "bunfig.toml" ]] && [[ -d "src" || -f "install.sh" ]]; }
 host_sync_into_vm() {
   need rsync
@@ -160,7 +180,6 @@ tarball_install_in_vm() {
       curl -fsSL ${url@Q} -o /tmp/org.tgz && ${verify} \
       tar -xzf /tmp/org.tgz -C /home/${SSH_USER}/org --strip-components=1'"
 }
-
 cmd_app_install() {
   local FROM="host" REPO_URL="https://github.com/tjamescouch/org.git" TAR_URL="" TAR_SHA="" NO_RUN="no"
   while [[ $# -gt 0 ]]; do
@@ -182,20 +201,18 @@ cmd_app_install() {
   [[ "$NO_RUN" == "yes" ]] || run_install_script
 }
 
-# ---------- high-level UX ----------
+# ---- UX commands ----
 cmd_quickstart() {
   if [[ "$(backend)" != "lima" ]]; then
     echo "quickstart is for Apple Silicon (Lima). On Intel: brew install --cask virtualbox && orgctl vm init && orgctl vm ssh" >&2
     exit 1
   fi
-  # Validate we can resolve a Lima config first
-  local cfg; cfg="$(lima_config_path)"
+  local cfg; cfg="$(lima_config_path)"; ensure_socket_vmnet_if_needed "$cfg"
   echo "Using Lima config: $cfg"
-  lima_vm_init
-  lima_vm_ssh
+  lima_vm_init                 # create or start (idempotent, non-blocking on 1.2.x)
+  exec limactl shell org.lima  # <-- take over the TTY; never “returns” until you exit the VM
 }
 
-# ---------- dispatcher ----------
 cmd_vm() {
   local sub="${1:-}"; shift || true
   case "$(backend)" in
@@ -223,13 +240,12 @@ cmd_vm() {
       ;;
   esac
 }
-
 usage() {
   cat <<EOF
 orgctl v$VERSION
 
 USAGE:
-  orgctl quickstart                              # Apple Silicon: ensure VM up + open shell
+  orgctl quickstart
   orgctl vm <init|up|stop|destroy|ssh|export>
   orgctl app install [--from host|git|tar] [--repo URL] [--tar-url URL --tar-sha256 SHA] [--no-run]
   orgctl version

--- a/orgctl
+++ b/orgctl
@@ -7,102 +7,76 @@
 #   1) $ORG_LIMA_CONFIG
 #   2) $PWD/.org/config/org.lima.yaml
 #   3) $HOME/.config/org/org.lima.yaml
-#   4) $ORG_DIR/.org/config/org.lima.yaml   (vendored next to the installed script)
-# Fail-fast by default.
+#   4) $ORG_DIR/.org/config/org.lima.yaml
 
 set -euo pipefail
-VERSION="0.6.1"
+VERSION="0.6.2"
 
-# Path where this script lives (brew installs into .../Cellar/org/<ver>/libexec/)
 ORG_DIR="$(cd "$(dirname "$0")" && pwd)"
-
-# Defaults
 VM_NAME="org-vm"
 HOST_SSH_PORT="${HOST_SSH_PORT:-2222}"
-SSH_USER="$(whoami)"   # Lima 1.2.x mirrors host username by default
+SSH_USER="$(whoami)"   # Lima 1.2.x mirrors host username
 
-# ---------- helpers ----------
 backend() {
   local arch sys
-  arch="$(uname -m)"
-  sys="$(uname -s)"
+  arch="$(uname -m)"; sys="$(uname -s)"
   if [[ "$arch" == "arm64" && "$sys" == "Darwin" ]]; then
     echo "lima"
   elif [[ "$arch" == "x86_64" ]]; then
     echo "vbox"
   else
-    echo "Unsupported arch: $arch ($sys)" >&2
-    exit 1
+    echo "Unsupported arch: $arch ($sys)" >&2; exit 1
   fi
 }
-
 need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }; }
+ssh_base() { echo "-p" "$HOST_SSH_PORT" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null"; }
 
-ssh_base() {
-  # Always talk to guest via localhost:2222 with relaxed hostkey checks
-  echo "-p" "$HOST_SSH_PORT" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null"
-}
-
-# Resolve the Lima profile path using the agreed precedence
 lima_config_path() {
   local cands=()
-
-  # 1) Explicit env override
-  if [[ -n "${ORG_LIMA_CONFIG:-}" ]]; then
-    cands+=("$ORG_LIMA_CONFIG")
-  fi
-  # 2) Project-local (run from a repo root)
-  cands+=("$PWD/.org/config/org.lima.yaml")
-  # 3) User config
-  cands+=("$HOME/.config/org/org.lima.yaml")
-  # 4) Vendored next to the installed script (brew libexec path)
-  cands+=("$ORG_DIR/.org/config/org.lima.yaml")
-
-  local p
-  for p in "${cands[@]}"; do
-    if [[ -f "$p" ]]; then
-      echo "$p"
-      return 0
-    fi
-  done
-
-  # Nice error explaining how to fix
+  [[ -n "${ORG_LIMA_CONFIG:-}" ]] && cands+=("$ORG_LIMA_CONFIG")
+  cands+=("$PWD/.org/config/org.lima.yaml" "$HOME/.config/org/org.lima.yaml" "$ORG_DIR/.org/config/org.lima.yaml")
+  for p in "${cands[@]}"; do [[ -f "$p" ]] && { echo "$p"; return; }; done
   cat >&2 <<'EOF'
-orgctl: could not find a Lima profile (org.lima.yaml).
-
-Searched (in order):
-  1) $ORG_LIMA_CONFIG (set this to an absolute path to your YAML)
-  2) $PWD/.org/config/org.lima.yaml
-  3) $HOME/.config/org/org.lima.yaml
-  4) $ORG_DIR/.org/config/org.lima.yaml (vendored)
-
-Fix options:
-  export ORG_LIMA_CONFIG="$PWD/.org/config/org.lima.yaml"   # from your project root
+orgctl: could not find org.lima.yaml
+Searched:
+  $ORG_LIMA_CONFIG
+  $PWD/.org/config/org.lima.yaml
+  $HOME/.config/org/org.lima.yaml
+  $ORG_DIR/.org/config/org.lima.yaml
+Fix with:
+  export ORG_LIMA_CONFIG="$PWD/.org/config/org.lima.yaml"
   # or
   mkdir -p ~/.config/org && ln -s "$PWD/.org/config/org.lima.yaml" ~/.config/org/org.lima.yaml
 EOF
   exit 1
 }
 
-# ---------- Lima backend (Apple Silicon) ----------
+# ---------- Lima backend ----------
+lima_exists() {
+  # robust for Lima 1.2.x: directory check; also try limactl list if present
+  [[ -d "$HOME/.lima/org.lima" ]] && return 0
+  limactl list 2>/dev/null | awk 'NR>1{print $1}' | grep -qx "org.lima" 2>/dev/null
+}
 lima_vm_init() {
   need limactl
-  local cfg
-  cfg="$(lima_config_path)"
-  echo "Starting Lima VM with config: $cfg"
-  # Lima 1.2.x has no --detach; this will stream logs until boot completes
-  limactl start --name org.lima "$cfg"
+  if lima_exists; then
+    echo "Lima instance org.lima already exists; starting it."
+    limactl start org.lima || true
+  else
+    local cfg; cfg="$(lima_config_path)"
+    echo "Creating Lima VM with config: $cfg"
+    # Lima 1.2.x has no --detach; this will stream logs until boot completes
+    limactl start --name org.lima "$cfg"
+  fi
 }
-
-lima_vm_up()      { need limactl; limactl start --name org.lima || true; }
+lima_vm_up()      { need limactl; limactl start org.lima || true; }
 lima_vm_stop()    { need limactl; limactl stop org.lima || true; }
 lima_vm_destroy() { need limactl; limactl delete org.lima || true; }
 lima_vm_ssh()     { need limactl; limactl shell org.lima; }
 lima_vm_export()  { echo "Export not supported for Lima"; }
 
-# ---------- VirtualBox backend (Intel) ----------
+# ---------- VirtualBox backend ----------
 assert_virtualbox() { need VBoxManage; }
-
 vbox_vm_init() {
   assert_virtualbox
   if VBoxManage list vms | grep -q "\"$VM_NAME\""; then
@@ -116,11 +90,8 @@ vbox_vm_destroy() { assert_virtualbox; VBoxManage unregistervm "$VM_NAME" --dele
 vbox_vm_ssh()     { ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1"; }
 vbox_vm_export()  { assert_virtualbox; VBoxManage export "$VM_NAME" --output "$VM_NAME.ova"; }
 
-# ---------- App install flows (common) ----------
-looks_like_org_repo() {
-  [[ -f "package.json" || -f "bun.toml" || -f "bunfig.toml" ]] && [[ -d "src" || -f "install.sh" ]]
-}
-
+# ---------- App install (common) ----------
+looks_like_org_repo() { [[ -f "package.json" || -f "bun.toml" || -f "bunfig.toml" ]] && [[ -d "src" || -f "install.sh" ]]; }
 host_sync_into_vm() {
   need rsync
   local tmp_excl; tmp_excl="$(mktemp)"
@@ -133,41 +104,30 @@ build/
 .DS_Store
 EOF
   echo "Syncing current directory to /home/${SSH_USER}/org ..."
-  rsync -az --delete --progress \
-    --exclude-from="$tmp_excl" \
-    -e "ssh $(ssh_base | xargs echo)" \
-    ./ "${SSH_USER}@127.0.0.1:/home/${SSH_USER}/org/"
+  rsync -az --delete --progress --exclude-from="$tmp_excl" -e "ssh $(ssh_base | xargs echo)" ./ \
+    "${SSH_USER}@127.0.0.1:/home/${SSH_USER}/org/"
   rm -f "$tmp_excl"
 }
-
 run_install_script() {
   echo "Running install.sh inside VM ..."
   ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1" \
     "bash -lc 'chmod +x /home/${SSH_USER}/org/install.sh || true; /home/${SSH_USER}/org/install.sh'"
 }
-
 git_clone_in_vm() {
   local url="$1"
   ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1" \
     "bash -lc 'rm -rf /home/${SSH_USER}/org && git clone ${url} /home/${SSH_USER}/org'"
 }
-
 tarball_install_in_vm() {
   local url="$1" sha="$2"
-  local verify=""
-  [[ -n "$sha" ]] && verify="echo '${sha}  /tmp/org.tgz' | sha256sum -c - &&"
+  local verify=""; [[ -n "$sha" ]] && verify="echo '${sha}  /tmp/org.tgz' | sha256sum -c - &&"
   ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1" \
     "bash -lc 'rm -rf /home/${SSH_USER}/org && mkdir -p /home/${SSH_USER}/org && \
       curl -fsSL ${url@Q} -o /tmp/org.tgz && ${verify} \
       tar -xzf /tmp/org.tgz -C /home/${SSH_USER}/org --strip-components=1'"
 }
-
 cmd_app_install() {
-  local FROM="host"
-  local REPO_URL="https://github.com/tjamescouch/org.git"
-  local TAR_URL=""; local TAR_SHA=""
-  local NO_RUN="no"
-
+  local FROM="host" REPO_URL="https://github.com/tjamescouch/org.git" TAR_URL="" TAR_SHA="" NO_RUN="no"
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --from) FROM="$2"; shift 2;;
@@ -178,18 +138,15 @@ cmd_app_install() {
       *) echo "Unknown option: $1" >&2; exit 1;;
     esac
   done
-
   case "$FROM" in
     host) looks_like_org_repo && host_sync_into_vm || git_clone_in_vm "$REPO_URL" ;;
     git)  git_clone_in_vm "$REPO_URL" ;;
     tar)  tarball_install_in_vm "$TAR_URL" "$TAR_SHA" ;;
     *)    echo "--from must be host|git|tar" >&2; exit 1 ;;
   esac
-
   [[ "$NO_RUN" == "yes" ]] || run_install_script
 }
 
-# ---------- dispatcher ----------
 cmd_vm() {
   local sub="${1:-}"; shift || true
   case "$(backend)" in
@@ -232,7 +189,6 @@ ENV:
 EOF
 }
 
-# ---------- main ----------
 case "${1:-}" in
   vm) shift; cmd_vm "$@" ;;
   app) shift; sub="${1:-}"; shift || true

--- a/orgctl
+++ b/orgctl
@@ -1,20 +1,29 @@
 #!/usr/bin/env bash
 # orgctl - MIT License
 # Unified orchestration CLI for org
-# - Apple Silicon (arm64): Lima backend with .org/config/org.lima.yaml
+# - Apple Silicon (arm64): Lima backend (Lima 1.2.x compatible)
 # - Intel (x86_64): VirtualBox backend
-# Works with Lima 1.2.1 (no --detach / --user flags)
+# Lima config search order:
+#   1) $ORG_LIMA_CONFIG
+#   2) $PWD/.org/config/org.lima.yaml
+#   3) $HOME/.config/org/org.lima.yaml
+#   4) $ORG_DIR/.org/config/org.lima.yaml   (vendored next to the installed script)
+# Fail-fast by default.
 
 set -euo pipefail
-VERSION="0.6.0"
+VERSION="0.6.1"
 
+# Path where this script lives (brew installs into .../Cellar/org/<ver>/libexec/)
 ORG_DIR="$(cd "$(dirname "$0")" && pwd)"
-LIMA_CONFIG="$ORG_DIR/.org/config/org.lima.yaml"
+
+# Defaults
 VM_NAME="org-vm"
 HOST_SSH_PORT="${HOST_SSH_PORT:-2222}"
-SSH_USER="$(whoami)"   # default to host username (works in Lima 1.2.1)
+SSH_USER="$(whoami)"   # Lima 1.2.x mirrors host username by default
 
+# ---------- helpers ----------
 backend() {
+  local arch sys
   arch="$(uname -m)"
   sys="$(uname -s)"
   if [[ "$arch" == "arm64" && "$sys" == "Darwin" ]]; then
@@ -27,25 +36,71 @@ backend() {
   fi
 }
 
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }; }
+
 ssh_base() {
+  # Always talk to guest via localhost:2222 with relaxed hostkey checks
   echo "-p" "$HOST_SSH_PORT" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null"
 }
 
-# ---------- Lima backend ----------
-lima_vm_init() {
-  [[ -f "$LIMA_CONFIG" ]] || { echo "Missing $LIMA_CONFIG"; exit 1; }
-  # Lima 1.2.1 has no --detach, so this will stream logs until boot completes.
-  echo "Starting Lima VM with config $LIMA_CONFIG ..."
-  limactl start --name org.lima "$LIMA_CONFIG"
-}
-lima_vm_up() { limactl start --name org.lima || true; }
-lima_vm_stop() { limactl stop org.lima || true; }
-lima_vm_destroy() { limactl delete org.lima || true; }
-lima_vm_ssh() { limactl shell org.lima; }
-lima_vm_export() { echo "Export not supported for Lima"; }
+# Resolve the Lima profile path using the agreed precedence
+lima_config_path() {
+  local cands=()
 
-# ---------- VirtualBox backend ----------
-need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }; }
+  # 1) Explicit env override
+  if [[ -n "${ORG_LIMA_CONFIG:-}" ]]; then
+    cands+=("$ORG_LIMA_CONFIG")
+  fi
+  # 2) Project-local (run from a repo root)
+  cands+=("$PWD/.org/config/org.lima.yaml")
+  # 3) User config
+  cands+=("$HOME/.config/org/org.lima.yaml")
+  # 4) Vendored next to the installed script (brew libexec path)
+  cands+=("$ORG_DIR/.org/config/org.lima.yaml")
+
+  local p
+  for p in "${cands[@]}"; do
+    if [[ -f "$p" ]]; then
+      echo "$p"
+      return 0
+    fi
+  done
+
+  # Nice error explaining how to fix
+  cat >&2 <<'EOF'
+orgctl: could not find a Lima profile (org.lima.yaml).
+
+Searched (in order):
+  1) $ORG_LIMA_CONFIG (set this to an absolute path to your YAML)
+  2) $PWD/.org/config/org.lima.yaml
+  3) $HOME/.config/org/org.lima.yaml
+  4) $ORG_DIR/.org/config/org.lima.yaml (vendored)
+
+Fix options:
+  export ORG_LIMA_CONFIG="$PWD/.org/config/org.lima.yaml"   # from your project root
+  # or
+  mkdir -p ~/.config/org && ln -s "$PWD/.org/config/org.lima.yaml" ~/.config/org/org.lima.yaml
+EOF
+  exit 1
+}
+
+# ---------- Lima backend (Apple Silicon) ----------
+lima_vm_init() {
+  need limactl
+  local cfg
+  cfg="$(lima_config_path)"
+  echo "Starting Lima VM with config: $cfg"
+  # Lima 1.2.x has no --detach; this will stream logs until boot completes
+  limactl start --name org.lima "$cfg"
+}
+
+lima_vm_up()      { need limactl; limactl start --name org.lima || true; }
+lima_vm_stop()    { need limactl; limactl stop org.lima || true; }
+lima_vm_destroy() { need limactl; limactl delete org.lima || true; }
+lima_vm_ssh()     { need limactl; limactl shell org.lima; }
+lima_vm_export()  { echo "Export not supported for Lima"; }
+
+# ---------- VirtualBox backend (Intel) ----------
 assert_virtualbox() { need VBoxManage; }
 
 vbox_vm_init() {
@@ -55,21 +110,21 @@ vbox_vm_init() {
   fi
   echo "TODO: implement full VBox unattended install"
 }
-vbox_vm_up() { VBoxManage startvm "$VM_NAME" --type headless; }
-vbox_vm_stop() { VBoxManage controlvm "$VM_NAME" acpipowerbutton || true; }
-vbox_vm_destroy() { VBoxManage unregistervm "$VM_NAME" --delete || true; }
-vbox_vm_ssh() { ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1"; }
-vbox_vm_export() { VBoxManage export "$VM_NAME" --output "$VM_NAME.ova"; }
+vbox_vm_up()      { assert_virtualbox; VBoxManage startvm "$VM_NAME" --type headless; }
+vbox_vm_stop()    { assert_virtualbox; VBoxManage controlvm "$VM_NAME" acpipowerbutton || true; }
+vbox_vm_destroy() { assert_virtualbox; VBoxManage unregistervm "$VM_NAME" --delete || true; }
+vbox_vm_ssh()     { ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1"; }
+vbox_vm_export()  { assert_virtualbox; VBoxManage export "$VM_NAME" --output "$VM_NAME.ova"; }
 
-# ---------- App install ----------
+# ---------- App install flows (common) ----------
 looks_like_org_repo() {
-  [[ -f "package.json" || -f "bun.toml" ]] && [[ -d "src" || -f "install.sh" ]]
+  [[ -f "package.json" || -f "bun.toml" || -f "bunfig.toml" ]] && [[ -d "src" || -f "install.sh" ]]
 }
 
 host_sync_into_vm() {
   need rsync
   local tmp_excl; tmp_excl="$(mktemp)"
-  cat > "$tmp_excl" <<EOF
+  cat > "$tmp_excl" <<'EOF'
 .git/
 node_modules/
 dist/
@@ -77,7 +132,7 @@ build/
 .cache/
 .DS_Store
 EOF
-  echo "Syncing current directory to ~/org ..."
+  echo "Syncing current directory to /home/${SSH_USER}/org ..."
   rsync -az --delete --progress \
     --exclude-from="$tmp_excl" \
     -e "ssh $(ssh_base | xargs echo)" \
@@ -108,55 +163,56 @@ tarball_install_in_vm() {
 }
 
 cmd_app_install() {
-  FROM="host"
-  REPO_URL="https://github.com/tjamescouch/org.git"
-  TAR_URL=""; TAR_SHA=""
-  NO_RUN="no"
+  local FROM="host"
+  local REPO_URL="https://github.com/tjamescouch/org.git"
+  local TAR_URL=""; local TAR_SHA=""
+  local NO_RUN="no"
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --from) FROM="$2"; shift 2 ;;
-      --repo) REPO_URL="$2"; shift 2 ;;
-      --tar-url) TAR_URL="$2"; shift 2 ;;
-      --tar-sha256) TAR_SHA="$2"; shift 2 ;;
-      --no-run) NO_RUN="yes"; shift ;;
-      *) echo "Unknown option: $1"; exit 1 ;;
+      --from) FROM="$2"; shift 2;;
+      --repo) REPO_URL="$2"; shift 2;;
+      --tar-url) TAR_URL="$2"; shift 2;;
+      --tar-sha256) TAR_SHA="$2"; shift 2;;
+      --no-run) NO_RUN="yes"; shift;;
+      *) echo "Unknown option: $1" >&2; exit 1;;
     esac
   done
 
   case "$FROM" in
     host) looks_like_org_repo && host_sync_into_vm || git_clone_in_vm "$REPO_URL" ;;
-    git) git_clone_in_vm "$REPO_URL" ;;
-    tar) tarball_install_in_vm "$TAR_URL" "$TAR_SHA" ;;
+    git)  git_clone_in_vm "$REPO_URL" ;;
+    tar)  tarball_install_in_vm "$TAR_URL" "$TAR_SHA" ;;
+    *)    echo "--from must be host|git|tar" >&2; exit 1 ;;
   esac
 
   [[ "$NO_RUN" == "yes" ]] || run_install_script
 }
 
-# ---------- Dispatcher ----------
+# ---------- dispatcher ----------
 cmd_vm() {
-  sub="${1:-}"; shift || true
+  local sub="${1:-}"; shift || true
   case "$(backend)" in
     lima)
       case "$sub" in
-        init) lima_vm_init ;;
-        up) lima_vm_up ;;
-        stop) lima_vm_stop ;;
+        init)    lima_vm_init ;;
+        up)      lima_vm_up ;;
+        stop)    lima_vm_stop ;;
         destroy) lima_vm_destroy ;;
-        ssh) lima_vm_ssh ;;
-        export) lima_vm_export ;;
-        *) echo "Unknown vm subcommand: $sub"; exit 1 ;;
+        ssh)     lima_vm_ssh ;;
+        export)  lima_vm_export ;;
+        *) echo "Unknown vm subcommand: $sub" >&2; exit 1 ;;
       esac
       ;;
     vbox)
       case "$sub" in
-        init) vbox_vm_init ;;
-        up) vbox_vm_up ;;
-        stop) vbox_vm_stop ;;
+        init)    vbox_vm_init ;;
+        up)      vbox_vm_up ;;
+        stop)    vbox_vm_stop ;;
         destroy) vbox_vm_destroy ;;
-        ssh) vbox_vm_ssh ;;
-        export) vbox_vm_export ;;
-        *) echo "Unknown vm subcommand: $sub"; exit 1 ;;
+        ssh)     vbox_vm_ssh ;;
+        export)  vbox_vm_export ;;
+        *) echo "Unknown vm subcommand: $sub" >&2; exit 1 ;;
       esac
       ;;
   esac
@@ -168,12 +224,15 @@ orgctl v$VERSION
 
 USAGE:
   orgctl vm <init|up|stop|destroy|ssh|export>
-  orgctl app install [--from host|git|tar]
+  orgctl app install [--from host|git|tar] [--repo URL] [--tar-url URL --tar-sha256 SHA] [--no-run]
   orgctl version
+ENV:
+  ORG_LIMA_CONFIG   Absolute path to org.lima.yaml (overrides search)
+  HOST_SSH_PORT     SSH port to the guest (default 2222)
 EOF
 }
 
-# ---------- Main ----------
+# ---------- main ----------
 case "${1:-}" in
   vm) shift; cmd_vm "$@" ;;
   app) shift; sub="${1:-}"; shift || true

--- a/orgctl
+++ b/orgctl
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # orgctl - MIT License
-# v0.6.5
+# v0.6.6
 # - Apple Silicon (arm64): Lima backend (Lima 1.2.x compatible)
 # - Intel (x86_64): VirtualBox backend
 # Lima config search order:
@@ -10,7 +10,7 @@
 #   4) $ORG_DIR/.org/config/org.lima.yaml
 
 set -euo pipefail
-VERSION="0.6.5"
+VERSION="0.6.9"
 
 ORG_DIR="$(cd "$(dirname "$0")" && pwd)"
 VM_NAME="org-vm"
@@ -56,21 +56,46 @@ lima_exists() {
   [[ -d "$HOME/.lima/org.lima" ]] && return 0
   limactl list 2>/dev/null | awk 'NR>1{print $1}' | grep -qx "org.lima" 2>/dev/null
 }
-ensure_socket_vmnet_if_needed() {
-  local cfg="$1"
-  if [[ "$(uname -s)" == "Darwin" ]] && grep -qE '^[[:space:]]*networks:' "$cfg"; then
-    pgrep -f 'socket_vmnet' >/dev/null 2>&1 || {
-      cat >&2 <<'EOF'
-orgctl: Lima networking helper 'socket_vmnet' is not running.
-Run:
-  brew install socket_vmnet
+
+# --- socket_vmnet UX (interactive auto-fix) ---
+brew_has_socket_vmnet() { command -v brew >/dev/null 2>&1 && brew list --formula 2>/dev/null | grep -qx socket_vmnet; }
+socket_vmnet_running()  { pgrep -f '/socket_vmnet(/socket_vmnet)?' >/dev/null 2>&1 || pgrep -f 'socket_vmnet' >/dev/null 2>&1; }
+start_socket_vmnet()    {
+  if ! brew_has_socket_vmnet; then
+    echo "Installing socket_vmnet with Homebrew…"
+    brew install socket_vmnet || return 1
+  fi
+  echo "Starting socket_vmnet (requires sudo)…"
   sudo brew services start socket_vmnet
-Then re-run: orgctl quickstart
-EOF
-      exit 1
-    }
+}
+
+ensure_socket_vmnet_if_needed() {
+  # Only relevant on macOS when the profile declares networks (e.g., "shared")
+  [[ "$(uname -s)" == "Darwin" ]] || return 0
+  local cfg="$1"
+  grep -qE '^[[:space:]]*networks:' "$cfg" || return 0
+  socket_vmnet_running && return 0
+
+  # If non-interactive (CI), print guidance but don't look "fatal"
+  if [[ ! -t 0 || ! -t 1 ]]; then
+    echo "orgctl: socket_vmnet is not running; provisioning may stall." >&2
+    echo "To enable networking: brew install socket_vmnet && sudo brew services start socket_vmnet" >&2
+    return 0
+  fi
+
+  echo
+  echo "Networking helper 'socket_vmnet' is not running."
+  read -r -p "Install/start it now via Homebrew? [Y/n] " ans; ans=${ans:-Y}
+  if [[ $ans =~ ^[Yy]$ ]]; then
+    if ! start_socket_vmnet; then
+      echo "Could not start socket_vmnet. You can continue, but provisioning may stall." >&2
+    fi
+  else
+    echo "Continuing without socket_vmnet. If provisioning hangs, run:" >&2
+    echo "  brew install socket_vmnet && sudo brew services start socket_vmnet" >&2
   fi
 }
+
 lima_wait_ready() {
   local i=0 spin='|/-\'
   printf "Waiting for VM to become ready "
@@ -114,15 +139,13 @@ lima_vm_up()      { need limactl; lima_start_detached; }
 lima_vm_stop()    { need limactl; limactl stop org.lima || true; }
 lima_vm_destroy() { need limactl; limactl delete org.lima || true; }
 
-# Attach and start in ~/dev if present (avoids noisy cd to /Users/...).
+# Attach and start in ~/dev if present (avoid noisy cd to /Users/..)
 lima_vm_ssh() {
   need limactl
   local work="/home/$SSH_USER/dev"
   if lima_has_flag_shell --workdir; then
-    # newer Lima: request the workdir directly; fall back silently
     limactl shell --workdir "$work" org.lima 2>/dev/null || limactl shell org.lima
   else
-    # Lima 1.2.x: run a login shell after cd attempt
     limactl shell org.lima -- bash -lc "cd \"$work\" 2>/dev/null || true; exec bash -l"
   fi
 }
@@ -204,7 +227,7 @@ cmd_quickstart() {
   local cfg; cfg="$(lima_config_path)"; ensure_socket_vmnet_if_needed "$cfg"
   echo "Using Lima config: $cfg"
   lima_vm_init
-  # take over the TTY so it feels like a single command
+  # attach and prefer ~/dev if present
   if lima_has_flag_shell --workdir; then
     exec limactl shell --workdir "/home/$SSH_USER/dev" org.lima
   else
@@ -245,7 +268,7 @@ usage() {
 orgctl v$VERSION
 
 USAGE:
-  orgctl quickstart                              # Apple Silicon: ensure VM up + open shell in ~/dev
+  orgctl quickstart                              # Apple Silicon: ensure VM up + open shell (in ~/dev if available)
   orgctl vm <init|up|stop|destroy|ssh|export>
   orgctl app install [--from host|git|tar] [--repo URL] [--tar-url URL --tar-sha256 SHA] [--no-run]
   orgctl version

--- a/orgctl
+++ b/orgctl
@@ -1,36 +1,23 @@
 #!/usr/bin/env bash
 # orgctl - MIT License
-# v0.6.6
-# - Apple Silicon (arm64): Lima backend (Lima 1.2.x compatible)
-# - Intel (x86_64): VirtualBox backend
-# Lima config search order:
-#   1) $ORG_LIMA_CONFIG
-#   2) $PWD/.org/config/org.lima.yaml
-#   3) $HOME/.config/org/org.lima.yaml
-#   4) $ORG_DIR/.org/config/org.lima.yaml
+# v0.7.4
+# - Apple Silicon: Lima backend (Lima 1.2.x compatible; no --detach)
+# - Intel: minimal VBox shim
 
 set -euo pipefail
-VERSION="0.6.9"
+VERSION="0.7.4"
 
 ORG_DIR="$(cd "$(dirname "$0")" && pwd)"
-VM_NAME="org-vm"
-HOST_SSH_PORT="${HOST_SSH_PORT:-2222}"
-SSH_USER="$(whoami)"   # Lima 1.2.x mirrors host username
+SSH_USER="$(whoami)"
 
-# ---------- helpers ----------
-backend() {
-  local arch sys; arch="$(uname -m)"; sys="$(uname -s)"
-  if [[ "$arch" == "arm64" && "$sys" == "Darwin" ]]; then echo "lima"
-  elif [[ "$arch" == "x86_64" ]]; then echo "vbox"
-  else echo "Unsupported arch: $arch ($sys)" >&2; exit 1; fi
-}
-need()    { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }; }
-ssh_base(){ echo "-p" "$HOST_SSH_PORT" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null"; }
+# ---------- utils ----------
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing: $1" >&2; exit 1; }; }
+backend(){ local m s; m="$(uname -m)"; s="$(uname -s)"; [[ "$m" == "arm64" && "$s" == "Darwin" ]] && echo lima || { [[ "$m" == "x86_64" ]] && echo vbox || { echo "Unsupported: $m/$s" >&2; exit 1; }; }; }
 
-lima_config_path() {
+lima_cfg() {
   local p
   for p in "${ORG_LIMA_CONFIG:-}" "$PWD/.org/config/org.lima.yaml" "$HOME/.config/org/org.lima.yaml" "$ORG_DIR/.org/config/org.lima.yaml"; do
-    [[ -n "$p" && -f "$p" ]] && { echo "$p"; return; }
+    [[ -n "${p:-}" && -f "$p" ]] && { echo "$p"; return; }
   done
   cat >&2 <<'EOF'
 orgctl: could not find org.lima.yaml
@@ -49,245 +36,149 @@ EOF
   exit 1
 }
 
-# ---------- Lima helpers (1.2.x safe) ----------
-lima_has_flag_start() { limactl start -h 2>&1 | grep -q -- "$1"; }
-lima_has_flag_shell() { limactl shell -h 2>&1 | grep -q -- "$1"; }
-lima_exists() {
-  [[ -d "$HOME/.lima/org.lima" ]] && return 0
-  limactl list 2>/dev/null | awk 'NR>1{print $1}' | grep -qx "org.lima" 2>/dev/null
-}
+# ---------- Lima helpers ----------
+lima_exists() { [[ -d "$HOME/.lima/org.lima" ]] || limactl list 2>/dev/null | awk 'NR>1{print $1}' | grep -qx org.lima 2>/dev/null; }
 
-# --- socket_vmnet UX (interactive auto-fix) ---
-brew_has_socket_vmnet() { command -v brew >/dev/null 2>&1 && brew list --formula 2>/dev/null | grep -qx socket_vmnet; }
-socket_vmnet_running()  { pgrep -f '/socket_vmnet(/socket_vmnet)?' >/dev/null 2>&1 || pgrep -f 'socket_vmnet' >/dev/null 2>&1; }
-start_socket_vmnet()    {
-  if ! brew_has_socket_vmnet; then
-    echo "Installing socket_vmnet with Homebrew…"
-    brew install socket_vmnet || return 1
-  fi
-  echo "Starting socket_vmnet (requires sudo)…"
-  sudo brew services start socket_vmnet
-}
-
-ensure_socket_vmnet_if_needed() {
-  # Only relevant on macOS when the profile declares networks (e.g., "shared")
-  [[ "$(uname -s)" == "Darwin" ]] || return 0
-  local cfg="$1"
-  grep -qE '^[[:space:]]*networks:' "$cfg" || return 0
-  socket_vmnet_running && return 0
-
-  # If non-interactive (CI), print guidance but don't look "fatal"
-  if [[ ! -t 0 || ! -t 1 ]]; then
-    echo "orgctl: socket_vmnet is not running; provisioning may stall." >&2
-    echo "To enable networking: brew install socket_vmnet && sudo brew services start socket_vmnet" >&2
-    return 0
-  fi
-
-  echo
-  echo "Networking helper 'socket_vmnet' is not running."
-  read -r -p "Install/start it now via Homebrew? [Y/n] " ans; ans=${ans:-Y}
-  if [[ $ans =~ ^[Yy]$ ]]; then
-    if ! start_socket_vmnet; then
-      echo "Could not start socket_vmnet. You can continue, but provisioning may stall." >&2
-    fi
-  else
-    echo "Continuing without socket_vmnet. If provisioning hangs, run:" >&2
-    echo "  brew install socket_vmnet && sudo brew services start socket_vmnet" >&2
-  fi
-}
-
-lima_wait_ready() {
+lima_wait_ready(){
   local i=0 spin='|/-\'
   printf "Waiting for VM to become ready "
-  while (( i < 120 )); do
-    if limactl shell org.lima -- true >/dev/null 2>&1; then
-      printf "\r%-70s\r" ""; return 0
-    fi
+  while (( i < 180 )); do
+    limactl shell org.lima -- true >/dev/null 2>&1 && { printf "\r%-70s\r" ""; return 0; }
     printf "\rWaiting for VM to become ready %c" "${spin:i%4:1}"
     sleep 2; ((i++))
   done
-  printf "\nTimed out waiting for Lima guest. See logs:\n  tail -f ~/.lima/org.lima/serial*.log\n" >&2
+  printf "\nTimed out. See: tail -f ~/.lima/org.lima/serial*.log\n" >&2
   return 1
 }
-lima_start_detached() {
-  if lima_has_flag_start --detach; then
-    limactl start --name org.lima --detach || true
-  else
-    nohup limactl start --name org.lima >/tmp/orgctl-lima-start.log 2>&1 < /dev/null &
-    lima_wait_ready
+
+brew_prefix(){ command -v brew >/dev/null 2>&1 && brew --prefix || echo /opt/homebrew; }
+brew_has_vmnet(){ command -v brew >/dev/null 2>&1 && brew list --formula 2>/dev/null | grep -qx socket_vmnet; }
+vmnet_running(){ pgrep -f '/socket_vmnet(/socket_vmnet)?' >/dev/null 2>&1 || pgrep -f 'socket_vmnet' >/dev/null 2>&1; }
+
+ensure_vmnet_binary() {
+  [[ "$(uname -s)" == "Darwin" ]] || return 0
+  local hb="$(brew_prefix)/opt/socket_vmnet/bin/socket_vmnet"
+  local sys="/opt/socket_vmnet/bin/socket_vmnet"
+  if [[ -L "$sys" ]]; then
+    echo "Replacing symlink $sys with real binary copy (Lima 1.2.x requirement)"
+    sudo rm "$sys"
+    sudo cp "$hb" "$sys"
+    sudo chmod 755 "$sys"
+  elif [[ ! -x "$sys" ]]; then
+    echo "Installing socket_vmnet with Homebrew…"
+    brew install socket_vmnet
+    sudo mkdir -p /opt/socket_vmnet/bin
+    sudo cp "$hb" "$sys"
+    sudo chmod 755 "$sys"
   fi
 }
 
-# ---------- Lima backend ----------
-lima_vm_init() {
-  need limactl
+start_vmnet(){
+  ensure_vmnet_binary || true
+  brew_has_vmnet || brew install socket_vmnet
+  echo "Starting socket_vmnet (requires sudo)…"
+  sudo brew services restart socket_vmnet
+}
+
+ensure_vmnet_if_needed(){
+  [[ "$(uname -s)" == "Darwin" ]] || return 0
+  local cfg="$1"
+  grep -qE '^[[:space:]]*networks:' "$cfg" || return 0
+  vmnet_running && return 0
+  if [[ -t 0 && -t 1 ]]; then
+    echo
+    echo "Networking helper 'socket_vmnet' is not running."
+    read -r -p "Fix/install/start it now via Homebrew (sudo)? [Y/n] " ans; ans=${ans:-Y}
+    [[ $ans =~ ^[Yy]$ ]] && start_vmnet || echo "Continuing without it (provisioning may stall)…"
+  else
+    echo "orgctl: socket_vmnet not running; provisioning may stall." >&2
+  fi
+}
+
+lima_start() {
+  local cfg="$1"
   if lima_exists; then
-    echo "Lima instance org.lima already exists; starting it."
-    lima_start_detached
+    echo "Starting existing Lima instance…"
+    nohup limactl start org.lima >/tmp/orgctl-lima-start.log 2>&1 < /dev/null &
   else
-    local cfg; cfg="$(lima_config_path)"; ensure_socket_vmnet_if_needed "$cfg"
-    echo "Creating Lima VM with config: $cfg"
-    if lima_has_flag_start --detach; then
-      limactl start --name org.lima --detach "$cfg"
-    else
-      nohup limactl start --name org.lima "$cfg" >/tmp/orgctl-lima-create.log 2>&1 < /dev/null &
-      lima_wait_ready
-    fi
+    echo "Creating Lima instance from $cfg …"
+    nohup limactl start --name org.lima "$cfg" >/tmp/orgctl-lima-create.log 2>&1 < /dev/null &
+  fi
+  lima_wait_ready
+}
+
+tail_vm_log() {
+  local log
+  log="$(ls -1t ~/.lima/org.lima/serial*.log 2>/dev/null | head -n1 || true)"
+  [[ -n "$log" ]] || return 0
+  echo "Tailing VM console log ($log)…"
+  tail -f "$log" &
+  TAIL_PID=$!
+  trap "kill $TAIL_PID 2>/dev/null || true" EXIT INT TERM
+}
+
+lima_attach() {
+  echo "Attaching to VM…"
+  if limactl shell -h 2>&1 | grep -q -- '--workdir'; then
+    limactl shell --workdir "/home/$SSH_USER.linux/dev" org.lima || limactl shell org.lima
+  else
+    limactl shell org.lima -- bash -lc 'cd "$HOME/dev" 2>/dev/null || cd ~; exec bash -l'
   fi
 }
-lima_vm_up()      { need limactl; lima_start_detached; }
-lima_vm_stop()    { need limactl; limactl stop org.lima || true; }
-lima_vm_destroy() { need limactl; limactl delete org.lima || true; }
 
-# Attach and start in ~/dev if present (avoid noisy cd to /Users/..)
-lima_vm_ssh() {
-  need limactl
-  local work="/home/$SSH_USER/dev"
-  if lima_has_flag_shell --workdir; then
-    limactl shell --workdir "$work" org.lima 2>/dev/null || limactl shell org.lima
-  else
-    limactl shell org.lima -- bash -lc "cd \"$work\" 2>/dev/null || true; exec bash -l"
-  fi
-}
-lima_vm_export()  { echo "Export not supported for Lima"; }
+# ---------- VBox stub ----------
+vbox_init(){ echo "TODO: VBox unattended install"; }
 
-# ---------- VirtualBox backend (kept minimal) ----------
-assert_virtualbox() { need VBoxManage; }
-vbox_vm_init() { assert_virtualbox; echo "TODO: implement VBox unattended install"; }
-vbox_vm_up()      { assert_virtualbox; VBoxManage startvm "$VM_NAME" --type headless; }
-vbox_vm_stop()    { assert_virtualbox; VBoxManage controlvm "$VM_NAME" acpipowerbutton || true; }
-vbox_vm_destroy() { assert_virtualbox; VBoxManage unregistervm "$VM_NAME" --delete || true; }
-vbox_vm_ssh()     { ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1"; }
-vbox_vm_export()  { assert_virtualbox; VBoxManage export "$VM_NAME" --output "$VM_NAME.ova"; }
-
-# ---------- App install (shared) ----------
-looks_like_org_repo() { [[ -f "package.json" || -f "bun.toml" || -f "bunfig.toml" ]] && [[ -d "src" || -f "install.sh" ]]; }
-host_sync_into_vm() {
-  need rsync
-  local tmp_excl; tmp_excl="$(mktemp)"
-  cat > "$tmp_excl" <<'EOF'
-.git/
-node_modules/
-dist/
-build/
-.cache/
-.DS_Store
-EOF
-  echo "Syncing current directory to /home/${SSH_USER}/org ..."
-  rsync -az --delete --progress --exclude-from="$tmp_excl" \
-    -e "ssh $(ssh_base | xargs echo)" ./ \
-    "${SSH_USER}@127.0.0.1:/home/${SSH_USER}/org/"
-  rm -f "$tmp_excl"
-}
-run_install_script() {
-  echo "Running install.sh inside VM ..."
-  ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1" \
-    "bash -lc 'chmod -v +x /home/${SSH_USER}/org/install.sh || true; /home/${SSH_USER}/org/install.sh'"
-}
-git_clone_in_vm() {
-  local url="$1"
-  ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1" \
-    "bash -lc 'rm -rf /home/${SSH_USER}/org && git clone ${url} /home/${SSH_USER}/org'"
-}
-tarball_install_in_vm() {
-  local url="$1" sha="$2"
-  local verify=""; [[ -n "$sha" ]] && verify="echo '${sha}  /tmp/org.tgz' | sha256sum -c - &&"
-  ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1" \
-    "bash -lc 'rm -rf /home/${SSH_USER}/org && mkdir -p /home/${SSH_USER}/org && \
-      curl -fsSL ${url@Q} -o /tmp/org.tgz && ${verify} \
-      tar -xzf /tmp/org.tgz -C /home/${SSH_USER}/org --strip-components=1'"
-}
-cmd_app_install() {
-  local FROM="host" REPO_URL="https://github.com/tjamescouch/org.git" TAR_URL="" TAR_SHA="" NO_RUN="no"
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --from) FROM="$2"; shift 2;;
-      --repo) REPO_URL="$2"; shift 2;;
-      --tar-url) TAR_URL="$2"; shift 2;;
-      --tar-sha256) TAR_SHA="$2"; shift 2;;
-      --no-run) NO_RUN="yes"; shift;;
-      *) echo "Unknown option: $1" >&2; exit 1;;
-    esac
-  done
-  case "$FROM" in
-    host) looks_like_org_repo && host_sync_into_vm || git_clone_in_vm "$REPO_URL" ;;
-    git)  git_clone_in_vm "$REPO_URL" ;;
-    tar)  tarball_install_in_vm "$TAR_URL" "$TAR_SHA" ;;
-    *)    echo "--from must be host|git|tar" >&2; exit 1 ;;
-  esac
-  [[ "$NO_RUN" == "yes" ]] || run_install_script
-}
-
-# ---------- UX ----------
+# ---------- commands ----------
 cmd_quickstart() {
   if [[ "$(backend)" != "lima" ]]; then
-    echo "quickstart is for Apple Silicon (Lima). On Intel: brew install --cask virtualbox && orgctl vm init && orgctl vm ssh" >&2
+    echo "quickstart is for Apple Silicon (Lima)." >&2
     exit 1
   fi
-  local cfg; cfg="$(lima_config_path)"; ensure_socket_vmnet_if_needed "$cfg"
+  need limactl
+  local cfg; cfg="$(lima_cfg)"
+  ensure_vmnet_if_needed "$cfg"
   echo "Using Lima config: $cfg"
-  lima_vm_init
-  # attach and prefer ~/dev if present
-  if lima_has_flag_shell --workdir; then
-    exec limactl shell --workdir "/home/$SSH_USER/dev" org.lima
-  else
-    exec limactl shell org.lima -- bash -lc 'cd "$HOME/dev" 2>/dev/null || true; exec bash -l'
-  fi
+  lima_start "$cfg"
+  tail_vm_log
+  lima_attach
 }
 
-cmd_vm() {
+cmd_vm(){
   local sub="${1:-}"; shift || true
   case "$(backend)" in
     lima)
       case "$sub" in
-        init)    lima_vm_init ;;
-        up)      lima_vm_up ;;
-        stop)    lima_vm_stop ;;
-        destroy) lima_vm_destroy ;;
-        ssh)     lima_vm_ssh ;;
-        export)  lima_vm_export ;;
-        *) echo "Unknown vm subcommand: $sub" >&2; exit 1 ;;
+        init|up)  need limactl; ensure_vmnet_if_needed "$(lima_cfg)"; lima_start "$(lima_cfg)";;
+        stop)     need limactl; limactl stop org.lima || true;;
+        destroy)  need limactl; limactl delete org.lima || true;;
+        ssh)      need limactl; lima_attach;;
+        export)   echo "Export not supported for Lima";;
+        *) echo "Unknown vm subcommand: $sub" >&2; exit 1;;
       esac
       ;;
     vbox)
       case "$sub" in
-        init)    vbox_vm_init ;;
-        up)      vbox_vm_up ;;
-        stop)    vbox_vm_stop ;;
-        destroy) vbox_vm_destroy ;;
-        ssh)     vbox_vm_ssh ;;
-        export)  vbox_vm_export ;;
-        *) echo "Unknown vm subcommand: $sub" >&2; exit 1 ;;
+        init) vbox_init;;
+        *) echo "Use VBox directly for now";;
       esac
       ;;
   esac
 }
 
-usage() {
-  cat <<EOF
+usage(){ cat <<EOF
 orgctl v$VERSION
-
 USAGE:
-  orgctl quickstart                              # Apple Silicon: ensure VM up + open shell (in ~/dev if available)
-  orgctl vm <init|up|stop|destroy|ssh|export>
-  orgctl app install [--from host|git|tar] [--repo URL] [--tar-url URL --tar-sha256 SHA] [--no-run]
+  orgctl quickstart
+  orgctl vm <init|up|stop|destroy|ssh>
   orgctl version
-
-ENV:
-  ORG_LIMA_CONFIG   Absolute path to org.lima.yaml (overrides search)
-  HOST_SSH_PORT     SSH port to the guest (default 2222)
 EOF
 }
 
 case "${1:-}" in
-  quickstart) shift; cmd_quickstart "$@" ;;
-  vm)         shift; cmd_vm "$@" ;;
-  app)        shift; sub="${1:-}"; shift || true
-              case "$sub" in
-                install) cmd_app_install "$@" ;;
-                *) usage; exit 1 ;;
-              esac ;;
-  version)    echo "$VERSION" ;;
-  ""|help|-h|--help) usage ;;
-  *)          usage; exit 1 ;;
+  quickstart) shift; cmd_quickstart "$@";;
+  vm)         shift; cmd_vm "$@";;
+  version)    echo "$VERSION";;
+  ""|help|-h|--help) usage;;
+  *) usage; exit 1;;
 esac

--- a/orgctl
+++ b/orgctl
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # orgctl - MIT License
-# v0.6.4
-# - Apple Silicon (arm64): Lima backend (Lima 1.2.x compatible; no --detach needed)
+# v0.6.5
+# - Apple Silicon (arm64): Lima backend (Lima 1.2.x compatible)
 # - Intel (x86_64): VirtualBox backend
 # Lima config search order:
 #   1) $ORG_LIMA_CONFIG
@@ -10,36 +10,26 @@
 #   4) $ORG_DIR/.org/config/org.lima.yaml
 
 set -euo pipefail
-VERSION="0.6.4"
+VERSION="0.6.5"
 
 ORG_DIR="$(cd "$(dirname "$0")" && pwd)"
 VM_NAME="org-vm"
 HOST_SSH_PORT="${HOST_SSH_PORT:-2222}"
 SSH_USER="$(whoami)"   # Lima 1.2.x mirrors host username
 
+# ---------- helpers ----------
 backend() {
-  local arch sys
-  arch="$(uname -m)"; sys="$(uname -s)"
-  if [[ "$arch" == "arm64" && "$sys" == "Darwin" ]]; then
-    echo "lima"
-  elif [[ "$arch" == "x86_64" ]]; then
-    echo "vbox"
-  else
-    echo "Unsupported arch: $arch ($sys)" >&2; exit 1
-  fi
+  local arch sys; arch="$(uname -m)"; sys="$(uname -s)"
+  if [[ "$arch" == "arm64" && "$sys" == "Darwin" ]]; then echo "lima"
+  elif [[ "$arch" == "x86_64" ]]; then echo "vbox"
+  else echo "Unsupported arch: $arch ($sys)" >&2; exit 1; fi
 }
-need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }; }
-ssh_base() { echo "-p" "$HOST_SSH_PORT" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null"; }
+need()    { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }; }
+ssh_base(){ echo "-p" "$HOST_SSH_PORT" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null"; }
 
-# ---- find Lima YAML ----
 lima_config_path() {
   local p
-  for p in \
-    "${ORG_LIMA_CONFIG:-}" \
-    "$PWD/.org/config/org.lima.yaml" \
-    "$HOME/.config/org/org.lima.yaml" \
-    "$ORG_DIR/.org/config/org.lima.yaml"
-  do
+  for p in "${ORG_LIMA_CONFIG:-}" "$PWD/.org/config/org.lima.yaml" "$HOME/.config/org/org.lima.yaml" "$ORG_DIR/.org/config/org.lima.yaml"; do
     [[ -n "$p" && -f "$p" ]] && { echo "$p"; return; }
   done
   cat >&2 <<'EOF'
@@ -59,50 +49,43 @@ EOF
   exit 1
 }
 
-# ---- Lima helpers (1.2.x safe) ----
-lima_has_flag() { limactl start -h 2>&1 | grep -q -- "$1"; }
+# ---------- Lima helpers (1.2.x safe) ----------
+lima_has_flag_start() { limactl start -h 2>&1 | grep -q -- "$1"; }
+lima_has_flag_shell() { limactl shell -h 2>&1 | grep -q -- "$1"; }
 lima_exists() {
   [[ -d "$HOME/.lima/org.lima" ]] && return 0
   limactl list 2>/dev/null | awk 'NR>1{print $1}' | grep -qx "org.lima" 2>/dev/null
 }
 ensure_socket_vmnet_if_needed() {
-  # If YAML requests networking, require socket_vmnet running (Darwin only)
   local cfg="$1"
-  if [[ "$(uname -s)" == "Darwin" ]]; then
-    if grep -qE '^[[:space:]]*networks:' "$cfg"; then
-      if ! pgrep -f '/opt/homebrew/.*/socket_vmnet(/socket_vmnet)?' >/dev/null 2>&1 \
-         && ! pgrep -f 'socket_vmnet' >/dev/null 2>&1; then
-        cat >&2 <<'EOF'
+  if [[ "$(uname -s)" == "Darwin" ]] && grep -qE '^[[:space:]]*networks:' "$cfg"; then
+    pgrep -f 'socket_vmnet' >/dev/null 2>&1 || {
+      cat >&2 <<'EOF'
 orgctl: Lima networking helper 'socket_vmnet' is not running.
 Run:
   brew install socket_vmnet
   sudo brew services start socket_vmnet
 Then re-run: orgctl quickstart
 EOF
-        exit 1
-      fi
-    fi
+      exit 1
+    }
   fi
 }
 lima_wait_ready() {
-  # Print a spinner/progress while waiting for guest agent
   local i=0 spin='|/-\'
   printf "Waiting for VM to become ready "
-  while (( i < 120 )); do  # ~4 minutes
+  while (( i < 120 )); do
     if limactl shell org.lima -- true >/dev/null 2>&1; then
-      printf "\r%-70s\r" ""  # clear line
-      return 0
+      printf "\r%-70s\r" ""; return 0
     fi
     printf "\rWaiting for VM to become ready %c" "${spin:i%4:1}"
     sleep 2; ((i++))
   done
-  printf "\n"
-  echo "Timed out waiting for Lima guest. See logs:" >&2
-  echo "  tail -f ~/.lima/org.lima/serial*.log" >&2
+  printf "\nTimed out waiting for Lima guest. See logs:\n  tail -f ~/.lima/org.lima/serial*.log\n" >&2
   return 1
 }
 lima_start_detached() {
-  if lima_has_flag --detach; then
+  if lima_has_flag_start --detach; then
     limactl start --name org.lima --detach || true
   else
     nohup limactl start --name org.lima >/tmp/orgctl-lima-start.log 2>&1 < /dev/null &
@@ -110,17 +93,16 @@ lima_start_detached() {
   fi
 }
 
-# ---- Lima backend ----
+# ---------- Lima backend ----------
 lima_vm_init() {
   need limactl
-  local cfg
   if lima_exists; then
     echo "Lima instance org.lima already exists; starting it."
     lima_start_detached
   else
-    cfg="$(lima_config_path)"; ensure_socket_vmnet_if_needed "$cfg"
+    local cfg; cfg="$(lima_config_path)"; ensure_socket_vmnet_if_needed "$cfg"
     echo "Creating Lima VM with config: $cfg"
-    if lima_has_flag --detach; then
+    if lima_has_flag_start --detach; then
       limactl start --name org.lima --detach "$cfg"
     else
       nohup limactl start --name org.lima "$cfg" >/tmp/orgctl-lima-create.log 2>&1 < /dev/null &
@@ -131,10 +113,22 @@ lima_vm_init() {
 lima_vm_up()      { need limactl; lima_start_detached; }
 lima_vm_stop()    { need limactl; limactl stop org.lima || true; }
 lima_vm_destroy() { need limactl; limactl delete org.lima || true; }
-lima_vm_ssh()     { need limactl; limactl shell org.lima; }
+
+# Attach and start in ~/dev if present (avoids noisy cd to /Users/...).
+lima_vm_ssh() {
+  need limactl
+  local work="/home/$SSH_USER/dev"
+  if lima_has_flag_shell --workdir; then
+    # newer Lima: request the workdir directly; fall back silently
+    limactl shell --workdir "$work" org.lima 2>/dev/null || limactl shell org.lima
+  else
+    # Lima 1.2.x: run a login shell after cd attempt
+    limactl shell org.lima -- bash -lc "cd \"$work\" 2>/dev/null || true; exec bash -l"
+  fi
+}
 lima_vm_export()  { echo "Export not supported for Lima"; }
 
-# ---- VirtualBox backend (kept minimal) ----
+# ---------- VirtualBox backend (kept minimal) ----------
 assert_virtualbox() { need VBoxManage; }
 vbox_vm_init() { assert_virtualbox; echo "TODO: implement VBox unattended install"; }
 vbox_vm_up()      { assert_virtualbox; VBoxManage startvm "$VM_NAME" --type headless; }
@@ -143,7 +137,7 @@ vbox_vm_destroy() { assert_virtualbox; VBoxManage unregistervm "$VM_NAME" --dele
 vbox_vm_ssh()     { ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1"; }
 vbox_vm_export()  { assert_virtualbox; VBoxManage export "$VM_NAME" --output "$VM_NAME.ova"; }
 
-# ---- App install (shared) ----
+# ---------- App install (shared) ----------
 looks_like_org_repo() { [[ -f "package.json" || -f "bun.toml" || -f "bunfig.toml" ]] && [[ -d "src" || -f "install.sh" ]]; }
 host_sync_into_vm() {
   need rsync
@@ -165,7 +159,7 @@ EOF
 run_install_script() {
   echo "Running install.sh inside VM ..."
   ssh "$(ssh_base[@])" "${SSH_USER}@127.0.0.1" \
-    "bash -lc 'chmod +x /home/${SSH_USER}/org/install.sh || true; /home/${SSH_USER}/org/install.sh'"
+    "bash -lc 'chmod -v +x /home/${SSH_USER}/org/install.sh || true; /home/${SSH_USER}/org/install.sh'"
 }
 git_clone_in_vm() {
   local url="$1"
@@ -201,7 +195,7 @@ cmd_app_install() {
   [[ "$NO_RUN" == "yes" ]] || run_install_script
 }
 
-# ---- UX commands ----
+# ---------- UX ----------
 cmd_quickstart() {
   if [[ "$(backend)" != "lima" ]]; then
     echo "quickstart is for Apple Silicon (Lima). On Intel: brew install --cask virtualbox && orgctl vm init && orgctl vm ssh" >&2
@@ -209,8 +203,13 @@ cmd_quickstart() {
   fi
   local cfg; cfg="$(lima_config_path)"; ensure_socket_vmnet_if_needed "$cfg"
   echo "Using Lima config: $cfg"
-  lima_vm_init                 # create or start (idempotent, non-blocking on 1.2.x)
-  exec limactl shell org.lima  # <-- take over the TTY; never “returns” until you exit the VM
+  lima_vm_init
+  # take over the TTY so it feels like a single command
+  if lima_has_flag_shell --workdir; then
+    exec limactl shell --workdir "/home/$SSH_USER/dev" org.lima
+  else
+    exec limactl shell org.lima -- bash -lc 'cd "$HOME/dev" 2>/dev/null || true; exec bash -l'
+  fi
 }
 
 cmd_vm() {
@@ -240,12 +239,13 @@ cmd_vm() {
       ;;
   esac
 }
+
 usage() {
   cat <<EOF
 orgctl v$VERSION
 
 USAGE:
-  orgctl quickstart
+  orgctl quickstart                              # Apple Silicon: ensure VM up + open shell in ~/dev
   orgctl vm <init|up|stop|destroy|ssh|export>
   orgctl app install [--from host|git|tar] [--repo URL] [--tar-url URL --tar-sha256 SHA] [--no-run]
   orgctl version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-multiagent-proto",
-  "version": "0.1.0",
+  "version": "0.6.9",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Description
< Enter a description >


## PR Checklist: Sandbox Matrix (8/8 must pass)

> **Pre-flight once per branch**
>
> ```bash
> # make sure the image exists
> ./create-container.sh     # or ./install.sh
>
> # start clean (optional but recommended)
> rm -rf .org/runs .org/logs
> ```
>
> All commands below assume the repo root. Replace `<CMD>` with the command you want the step to run.
> For “env propagation” checks we use `printenv | grep -E '^ORG_TEST=' || echo missing`.

### Legend

* **UI**: `--ui console` or `--ui tmux`
* **Mode**:

  * **non-interactive** → one step, captured output (uses `sandboxedSh`)
  * **interactive** → one interactive step (uses `shInteractive`)
* **Backend**:

  * **none** → no nested container; run directly in the app container
  * **podman** → nested container runner

---

### ✅ 1. console • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * `.org/logs/*` has no “posix\_spawn 'bash'” errors

* [ ] PASS

---

### ✅ 2. console • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * A single container session reused across steps (check `podman ps` name is stable)

* [ ] PASS

---

### ✅ 3. console • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

  > If your prompt driver doesn’t support the `interactive` keyword, trigger an interactive step via the UI or your testing harness; the key is to exercise `shInteractive`.

* **Expect**

  * Output contains `ORG_TEST=1`
  * **No** “posix\_spawn 'bash' ENOENT” anywhere

* [ ] PASS

---

### ✅ 4. console • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * Still only **one** container for the app and **one** nested podman for the step (if you keep nesting enabled); or none if your launcher sets `ORG_SANDBOX_BACKEND=none`

* [ ] PASS

---

### ✅ 5. tmux • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the tmux pane, run:

  ```
  run `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **ESC** emits the ACK and exits gracefully
  * **Ctrl+C** exits immediately (130)

* [ ] PASS

---

### ✅ 6. tmux • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane, run the same `printenv` step.

* **Expect**

  * Pane prints `ORG_TEST=1`
  * ESC ACK works; Ctrl+C exits immediately
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 7. tmux • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **Typing** must not crash the app (regression test from ESC/Ctrl+C fixes)
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 8. tmux • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * No extra containers spawned when not intended (depending on your launcher policy)

* [ ] PASS

---

## Add-on checks (tick if relevant to your PR)

* [ ] **ESC ack** works in console & tmux (no double-ACK, no freeze)
* [ ] **Ctrl+C** exits with code 130
* [ ] All step artifacts exist (`.org/runs/<id>/steps/step-*.{out,err,meta.json}`)
* [ ] No “sticky runner” surprises: `/work/.org/org-step.sh` is a fresh copy if the script changed
* [ ] CI logs contain no “posix\_spawn 'bash' ENOENT” or uncaught exceptions

---

## How to use this locally

* Run each command and tick the checkbox.
* If a tmux test fails, open `.org/logs/tmux-*.log` for the run and attach to your PR.
* If a console test fails, attach `.org/logs/*` and the newest `.org/runs/<id>/steps/` files.


