### PR TITLE
Revise installation instructions for clarity and detail

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,194 +1,164 @@
 
-# INSTALLATION
+# Installation (macOS & Linux)
 
-This guide shows how to install **org** with a **VM-backed sandbox** for safer runs and a reproducible developer experience.
-
-- **Apple Silicon (M-series macOS):** uses **Lima** as the VM backend.
-- **Intel macOS:** uses **VirtualBox**.
-- Linux notes and a legacy “container-only” path are included at the end.
-
-> If you just need the quick steps, see the README. This doc explains *why* each step exists, how to verify it, and how to troubleshoot.
+This guide gets you from **zero → running `org`** with a **VM-backed sandbox**.  
+On Apple Silicon we use **Lima**; on Intel macOS use **VirtualBox** (or prefer Lima if available).  
+Linux can run without a VM (container-only), but the VM path is the recommended hard boundary.
 
 ---
 
-## 0) What gets installed
+## Quick Start (Apple Silicon • macOS)
 
-- A tiny CLI, **`orgctl`**, installed via Homebrew.
-- A VM defined by **`.org/config/org.lima.yaml`** (Apple Silicon) or VirtualBox (Intel).
-- Inside the VM: minimal Ubuntu, Bun, Podman (optional), and a locked-down firewall (localhost-only by default).
-- Your **code** is mounted from the host into the VM at `~/dev` (and `~/scratch` is an in-VM tmpfs).
+> Clean, minimal path using Homebrew and `orgctl quickstart`.
 
----
-
-## 1) Prerequisites
-
-### macOS (Apple Silicon – recommended path)
 ```bash
+# 1) Install the CLI and VM helpers
 brew tap tjamescouch/org
-brew install org
-brew install lima                # VM provider for Apple Silicon
+brew install orgctl lima socket_vmnet
+
+# 2) Create + provision the VM, wait until org is installed, then attach
+orgctl quickstart --verbose --attach
 ````
 
-> **Why Lima?** VirtualBox is not practically usable on Apple Silicon; Lima wraps Apple’s native virtualization for a fast, light VM.
+Inside the VM (you’ll see a bright **\[VM]** prompt):
 
-### macOS (Intel)
+```bash
+# Sanity check a run
+org --ui console --prompt "hello"
+```
+
+**What `quickstart` does on first boot**
+
+* Creates the Lima VM from `.org/config/org.lima.yaml`.
+* Provisions the guest (Ubuntu, Bun, Podman optional), sets a **colorful prompt**, and hardens UFW.
+* Mounts your host `~/dev` at **`/home/<you>.linux/dev`** (so `~/dev` inside the VM shows your host repos).
+* Exposes your host LLM (LM Studio/Ollama) to the guest and sets:
+
+  ```
+  ORG_LLM_BASE_URL=http://192.168.5.2:11434
+  ```
+
+  (192.168.5.2 is Lima’s alias to the host’s 127.0.0.1; egress is allowed only to that port.)
+
+> First run may take a while (downloads + image build). `--verbose` prints honest progress and dots when it’s still working.
+
+---
+
+## Quick Start (Intel macOS)
+
+VirtualBox works on Intel, but Lima is preferred if you have it:
 
 ```bash
 brew tap tjamescouch/org
-brew install org
-brew install --cask virtualbox   # approve kext if macOS prompts
+brew install orgctl
+# If you don’t have Lima, install VirtualBox instead:
+brew install --cask virtualbox
+orgctl quickstart --verbose --attach
 ```
-
-### Linux (Debian/Ubuntu)
-
-You can run `org` directly or bring your own VM/hypervisor. For parity with macOS, QEMU/KVM works well, but is not wired into `orgctl` yet. See **Container-only (legacy)** below if you prefer no VM.
 
 ---
 
-## 2) Create and start the VM
-
-From the **repo root** (so `orgctl` finds the checked-in profile at `.org/config/org.lima.yaml`):
+## Day-to-day
 
 ```bash
-# Apple Silicon (Lima)
-./orgctl quickstart  # If you fail to connect on the first try run 
-./orgctl vm ssh      # open a shell inside the VM ./orgctl vm ssh
+# Start / stop / destroy the VM
+orgctl vm up
+orgctl vm stop
+orgctl vm destroy
+
+# Attach a shell in the VM
+orgctl vm ssh
 ```
-
-```bash
-# Intel (VirtualBox)
-./orgctl quickstart
-```
-
-**What the Lima profile does (Apple Silicon):**
-
-* Root disk **50 GiB**.
-* Mount host `~/dev →` guest `~/dev` (sane default; keeps personal files out).
-* `~/scratch` is tmpfs for ephemeral work.
-* Networking: **no external egress**; UFW allows only `127.0.0.1` (LMStudio/Ollama).
-  You can temporarily open HTTPS egress inside the VM if you need to pull images (see Troubleshooting).
 
 ---
 
-## 3) Put your code into the VM
+## Networking model (default)
 
-Choose one:
+* **Guest egress is denied** by default via UFW, except:
+
+  * loopback (`127.0.0.1`) and
+  * **guest → host LLM** on `192.168.5.2:11434` (Lima’s alias to the host loopback).
+* The installer sets and persists:
+
+  ```bash
+  ORG_LLM_BASE_URL=http://192.168.5.2:11434
+  ```
+
+  You can override at any time:
+
+  ```bash
+  export ORG_LLM_BASE_URL="http://host.lima.internal:11434"
+  ```
+
+---
+
+## Troubleshooting
+
+**Stuck at “Waiting for VM … boot scripts must have finished”**
+That’s Lima finishing cloud-init; `quickstart --verbose` keeps printing state lines until `org` is installed. If Lima prints a transient error but SSH becomes ready, `quickstart` continues and will still reach READY.
+
+**“orgctl vm ssh” says no instance / tries the wrong name**
+The VM name is `org.lima`. Use:
 
 ```bash
-# A) Sync your current checkout (no creds in the VM)
-./orgctl app install --from host
-
-# B) Clone inside the VM (HTTPS or SSH agent-forwarding)
-./orgctl app install --from git --repo https://github.com/<username>/org.git
-# or: ./orgctl app install --from git --repo git@github.com:<username>/org.git  (then use ssh-agent)
-
-# C) Verified tarball (no auth; reproducible)
-./orgctl app install --from tar \
-  --tar-url https://github.com/<username>/org/releases/download/vX.Y.Z/org-X.Y.Z.tgz \
-  --tar-sha256 <sha256>
+limactl list
+limactl shell org.lima
 ```
 
-All methods end with the repo at `~/org` (or under `~/dev/…` if you prefer).
-`--from host` is the safest default: the VM never sees your Git credentials.
-The <username> is either tjamescouch or your username if you forked the repository.
-
----
-
-## 4) Run and verify
-
-Inside the VM:
+**VM prompt isn’t colorful**
+You’re in a login shell that doesn’t source `~/.bashrc`. Provisioning adds the loader, but if you created the VM earlier, run once inside the VM:
 
 ```bash
-cd ~/dev/your-repo
-./install.sh        # This will take a while
-org                 # or: org --ui tmux
+printf '[ -r ~/.bashrc ] && . ~/.bashrc\n' >> ~/.bash_profile
+printf '\nfor f in ~/.bashrc.d/*.sh; do [ -r "$f" ] && . "$f"; done\n' >> ~/.bashrc
+exec bash -l
 ```
 
-Logs for the project appear under `<project>/.org/logs/…` on your host (because the project dir is mounted).
-
----
-
-## 5) Day-to-day commands
+**LM Studio/Ollama reachable?**
+From the VM:
 
 ```bash
-# Start or stop the VM
-./orgctl vm up
-./orgctl vm stop
-
-# Enter the VM shell
-./orgctl vm ssh
-
-# Rebuild from scratch (applies updated .org/config/org.lima.yaml)
-limactl delete org.lima || true
-./orgctl vm init
+curl -sS http://192.168.5.2:11434/api/tags | head
 ```
 
-> If you installed `orgctl` via Homebrew earlier, ensure your shell picks the **repo** version while developing:
-> `export PATH="$PWD:$PATH"` then `type -a orgctl` should show `./orgctl` first.
-
----
-
-## 6) Security model (quick read)
-
-* **VM boundary**: separate kernel and disk; only `~/dev` (and tmpfs scratch) are visible in the guest.
-* **Default egress**: blocked; only `127.0.0.1` allowed from inside VM (talk to LMStudio/Ollama on host).
-* **Safer than host/container**: the VM is the recommended “hard boundary.”
-* **Not an air-gap**: the mounted `~/dev` is read/write; treat it as in-scope for hostile code.
-
-> See **SECURITY.md** for vulnerability reporting and hardening tips (read-only mounts, per-project mounts, temporary egress rules, etc.).
-
----
-
-## 7) Troubleshooting
-
-**I see Lima boot logs and can’t type commands**
-That’s normal on Lima 1.2.x during `vm init`. Press **Ctrl-C** to detach; the VM stays up. Then `./orgctl vm ssh`.
-
-**`orgctl vm ssh` says “install VirtualBox” on Apple Silicon**
-Your shell is using the Homebrew `orgctl` instead of the repo copy. Run `export PATH="$PWD:$PATH"` or call `./orgctl …`. Check with `type -a orgctl`.
-
-**Where’s my disk space?**
-`df -h /` shows the VM’s root disk (50 GiB). `df -h ~/dev` shows your **host** free space—expected because it’s a mount.
-
-**Need to pull a container image in the VM**
-Inside the VM:
+If this fails, ensure LM Studio is running on the host and that UFW shows an allow rule:
 
 ```bash
-sudo ufw allow out 443/tcp
-podman pull docker.io/library/alpine:latest
-sudo ufw delete allow out 443/tcp
+sudo ufw status | grep 11434
 ```
 
-**VirtualBox on Apple Silicon?**
-Not supported in practice. Use Lima.
-
 ---
 
-## 8) Uninstall / clean up
+## Clean reset (Apple Silicon)
 
 ```bash
-# Remove the VM (Apple Silicon)
+# Remove the VM
 limactl stop org.lima || true
-limactl delete org.lima || true
+limactl delete -f org.lima || true
 
-# Remove brew CLI
-brew uninstall org
+# (Optional) wipe Lima caches to force fresh images
+rm -rf ~/Library/Caches/lima/*
+
+# Recreate in one go
+orgctl quickstart --verbose --attach
 ```
-
-VirtualBox users: also remove the VM from VirtualBox if created.
 
 ---
 
-## 9) Linux & Container-only (legacy)
-
-You can still run **without a VM** (less isolation):
+## Container-only (Linux or macOS) — optional tryout
 
 ```bash
-# Debian/Ubuntu
+# Linux example (Debian/Ubuntu)
 sudo apt-get update && sudo apt-get install -y podman git
 git clone https://github.com/tjamescouch/org.git
 cd org
 ./install.sh
 org --ui tmux --prompt "hello"
 ```
+
+> VM mode is recommended for a stronger boundary and consistent UX, but container-only is handy for quick tests.
+
+---
+
+
 


### PR DESCRIPTION
## Description
See title


## PR Checklist: Sandbox Matrix (8/8 must pass)

> **Pre-flight once per branch**
>
> ```bash
> # make sure the image exists
> ./create-container.sh     # or ./install.sh
>
> # start clean (optional but recommended)
> rm -rf .org/runs .org/logs
> ```
>
> All commands below assume the repo root. Replace `<CMD>` with the command you want the step to run.
> For “env propagation” checks we use `printenv | grep -E '^ORG_TEST=' || echo missing`.

### Legend

* **UI**: `--ui console` or `--ui tmux`
* **Mode**:

  * **non-interactive** → one step, captured output (uses `sandboxedSh`)
  * **interactive** → one interactive step (uses `shInteractive`)
* **Backend**:

  * **none** → no nested container; run directly in the app container
  * **podman** → nested container runner

---

### ✅ 1. console • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * `.org/logs/*` has no “posix\_spawn 'bash'” errors

* [ ] PASS

---

### ✅ 2. console • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * A single container session reused across steps (check `podman ps` name is stable)

* [ ] PASS

---

### ✅ 3. console • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

  > If your prompt driver doesn’t support the `interactive` keyword, trigger an interactive step via the UI or your testing harness; the key is to exercise `shInteractive`.

* **Expect**

  * Output contains `ORG_TEST=1`
  * **No** “posix\_spawn 'bash' ENOENT” anywhere

* [ ] PASS

---

### ✅ 4. console • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * Still only **one** container for the app and **one** nested podman for the step (if you keep nesting enabled); or none if your launcher sets `ORG_SANDBOX_BACKEND=none`

* [ ] PASS

---

### ✅ 5. tmux • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the tmux pane, run:

  ```
  run `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **ESC** emits the ACK and exits gracefully
  * **Ctrl+C** exits immediately (130)

* [ ] PASS

---

### ✅ 6. tmux • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane, run the same `printenv` step.

* **Expect**

  * Pane prints `ORG_TEST=1`
  * ESC ACK works; Ctrl+C exits immediately
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 7. tmux • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **Typing** must not crash the app (regression test from ESC/Ctrl+C fixes)
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 8. tmux • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * No extra containers spawned when not intended (depending on your launcher policy)

* [ ] PASS

---

## Add-on checks (tick if relevant to your PR)

* [ ] **ESC ack** works in console & tmux (no double-ACK, no freeze)
* [ ] **Ctrl+C** exits with code 130
* [ ] All step artifacts exist (`.org/runs/<id>/steps/step-*.{out,err,meta.json}`)
* [ ] No “sticky runner” surprises: `/work/.org/org-step.sh` is a fresh copy if the script changed
* [ ] CI logs contain no “posix\_spawn 'bash' ENOENT” or uncaught exceptions

---

## How to use this locally

* Run each command and tick the checkbox.
* If a tmux test fails, open `.org/logs/tmux-*.log` for the run and attach to your PR.
* If a console test fails, attach `.org/logs/*` and the newest `.org/runs/<id>/steps/` files.


