### PR TITLE
lipstick

### DIFF
--- a/org
+++ b/org
@@ -104,6 +104,7 @@ ENV_ARR=(
   "-e" "ORG_HOST_ALIAS=host.containers.internal"
   "-e" "NO_PROXY=localhost,127.0.0.1,::1,host.containers.internal"
   "-e" "ORG_OPENAI_BASE_DEFAULT=${ORG_OPENAI_BASE_DEFAULT:-http://host.containers.internal:11434/v1}"
+  "-e" "GIT_CONFIG_GLOBAL=/tmp/org/gitconfig"
 )
 
 env_allow() {
@@ -138,6 +139,7 @@ set +e
       rsync -a --delete  --delete-delay --force --exclude ".git/**" --exclude ".org/**" /project/ /work/
       rm -rf /work/.git 2>/dev/null || true
       printf "gitdir: /project/.git\n" > /work/.git
+      mkdir -p /tmp/org
       git config --global --add safe.directory /project >/dev/null 2>&1 || true
       git config --global --add safe.directory /work    >/dev/null 2>&1 || true
     fi

--- a/src/agents/llm-agent.ts
+++ b/src/agents/llm-agent.ts
@@ -141,7 +141,7 @@ export class LlmAgent extends Agent {
 
     let hop = 0;
 
-    Logger.info(C.green(`${this.id} ...`));
+    Logger.info(C.green(`${this.id} is thinking.`));
     const msgs = this.memory.messages();
     Logger.debug(`${this.id} chat ->`, { hop: hop++, msgs: msgs.length });
     const t0 = Date.now();
@@ -206,7 +206,7 @@ export class LlmAgent extends Agent {
       onToolCallDelta
     });
 
-    console.log("this.driver.chat", out);
+    Logger.debug("this.driver.chat", out);
 
     const tail = this.streamFilter.flush();                            // then flush filter
     if (tail) Logger.streamInfo(C.bold(tail) + "\n");

--- a/src/executors/standard-tool-executor.ts
+++ b/src/executors/standard-tool-executor.ts
@@ -25,7 +25,7 @@ const formatToolResult = (tr: ToolResult): string => {
 
 
 const shHandler = async (agentId: string, toolcall: ChatToolCall, text: string, memory: AgentMemory, guard: GuardRail): Promise<ToolHandlerResult> => {
-    console.log("shHanlder", toolcall);
+    Logger.debug("shHanlder", toolcall);
 
 
     let args: any = {};

--- a/src/input/utils.ts
+++ b/src/input/utils.ts
@@ -1,7 +1,8 @@
 import { Logger } from "../logger";
+import { R } from "../runtime/runtime";
 
 const DEBUG = (() => {
-  const v = (process.env.DEBUG ?? "").toString().toLowerCase();
+  const v = (R.env.DEBUG ?? "").toString().toLowerCase();
   return v === "1" || v === "true" || v === "yes" || v === "debug";
 })();
 
@@ -10,25 +11,25 @@ export function dbg(...a: any[]) {
 }
 
 export function enableRawMode() {
-  if (process.stdin.isTTY) {
-    try { (process.stdin as any).setRawMode(true); } catch (e) { Logger.error(e) }
+  if (R.stdin.isTTY) {
+    try { (R.stdin as any).setRawMode(true); } catch (e) { Logger.error(e) }
   }
 }
 
 export function disableRawMode() {
-  if (process.stdin.isTTY) {
-    try { (process.stdin as any).setRawMode(false); } catch (e) { Logger.error(e) }
+  if (R.stdin.isTTY) {
+    try { (R.stdin as any).setRawMode(false); } catch (e) { Logger.error(e) }
   }
 }
 
 export function pauseStdin() {
-  try { process.stdin.pause(); } catch (e) { Logger.error(e) }
+  try { R.stdin.pause(); } catch (e) { Logger.error(e) }
 }
 
 export function resumeStdin() {
-  try { process.stdin.resume(); } catch (e) { Logger.error(e) }
+  try { R.stdin.resume(); } catch (e) { Logger.error(e) }
 }
 
 export function isRaw(): boolean {
-  return !!(process.stdin as any).isRaw;
+  return !!(R.stdin as any).isRaw;
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,3 +1,5 @@
+import { R } from "./runtime/runtime";
+
 const Reset = "\u001b[0m";
 const Dim = "\u001b[2m";
 const FgCyan = "\u001b[36m";
@@ -31,8 +33,8 @@ const Colors = { Reset, Dim, FgCyan, FgGreen, FgMagenta, FgYellow, FgBlue };
 export class Logger {
   static info(...a: any[]) { console.log(...a); }
   static warn(...a: any[]) { console.warn(...a); }
-  static error(...a: any[]) { console.error(...a); }
-  static debug(...a: any[]) { if ((process.env.ORG_LOG_LEVEL||'').toUpperCase()==='DEBUG') console.log(...a); }
+  static error(...a: any[]) { console.error(...a); } // This must remain as process to prevent cyclic imports
+  static debug(...a: any[]) { if ((process.env.ORG_LOG_LEVEL ?? '').toUpperCase()==='DEBUG') console.log(...a); }
 
   /** stream without newline */
   static streamInfo(s: string) { writeRaw(s); }

--- a/src/runtime/process-guards.ts
+++ b/src/runtime/process-guards.ts
@@ -1,17 +1,18 @@
-// src/runtime/process-guards.ts
+// src/runtime/R-guards.ts
 import { Logger } from "../logger";
+import { R } from "./runtime";
 
-export function setupProcessGuards() {
-  const dbgOn = !!process.env.DEBUG && process.env.DEBUG !== "0" && process.env.DEBUG !== "false";
+export function setupRGuards() {
+  const dbgOn = !!R.env.DEBUG && R.env.DEBUG !== "0" && R.env.DEBUG !== "false";
   if (!dbgOn) return;
 
-  process.on("beforeExit", (code) => {
+  R.on("beforeExit", (code) => {
     Logger.info("[DBG] beforeExit", code, "— scheduler stays alive unless Ctrl+C");
     setTimeout(() => { /* keep loop alive while idle */ }, 60_000);
   });
-  process.on("uncaughtException", (e) => { Logger.info("[DBG] uncaughtException:", e); });
-  process.on("unhandledRejection", (e) => { Logger.info("[DBG] unhandledRejection:", e); });
-  process.stdin.on("end", () => Logger.info("[DBG] stdin end"));
-  process.stdin.on("pause", () => Logger.info("[DBG] stdin paused"));
-  process.stdin.on("resume", () => Logger.info("[DBG] stdin resumed"));
+  R.on("uncaughtException", (e) => { Logger.info("[DBG] uncaughtException:", e); });
+  R.on("unhandledRejection", (e) => { Logger.info("[DBG] unhandledRejection:", e); });
+  R.stdin.on("end", () => Logger.info("[DBG] stdin end"));
+  R.stdin.on("pause", () => Logger.info("[DBG] stdin paused"));
+  R.stdin.on("resume", () => Logger.info("[DBG] stdin resumed"));
 }


### PR DESCRIPTION
## Description
< Enter a description >


## PR Checklist: Sandbox Matrix (8/8 must pass)

> **Pre-flight once per branch**
>
> ```bash
> # make sure the image exists
> ./create-container.sh     # or ./install.sh
>
> # start clean (optional but recommended)
> rm -rf .org/runs .org/logs
> ```
>
> All commands below assume the repo root. Replace `<CMD>` with the command you want the step to run.
> For “env propagation” checks we use `printenv | grep -E '^ORG_TEST=' || echo missing`.

### Legend

* **UI**: `--ui console` or `--ui tmux`
* **Mode**:

  * **non-interactive** → one step, captured output (uses `sandboxedSh`)
  * **interactive** → one interactive step (uses `shInteractive`)
* **Backend**:

  * **none** → no nested container; run directly in the app container
  * **podman** → nested container runner

---

### ✅ 1. console • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * `.org/logs/*` has no “posix\_spawn 'bash'” errors

* [ ] PASS

---

### ✅ 2. console • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * A single container session reused across steps (check `podman ps` name is stable)

* [ ] PASS

---

### ✅ 3. console • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

  > If your prompt driver doesn’t support the `interactive` keyword, trigger an interactive step via the UI or your testing harness; the key is to exercise `shInteractive`.

* **Expect**

  * Output contains `ORG_TEST=1`
  * **No** “posix\_spawn 'bash' ENOENT” anywhere

* [ ] PASS

---

### ✅ 4. console • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * Still only **one** container for the app and **one** nested podman for the step (if you keep nesting enabled); or none if your launcher sets `ORG_SANDBOX_BACKEND=none`

* [ ] PASS

---

### ✅ 5. tmux • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the tmux pane, run:

  ```
  run `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **ESC** emits the ACK and exits gracefully
  * **Ctrl+C** exits immediately (130)

* [ ] PASS

---

### ✅ 6. tmux • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane, run the same `printenv` step.

* **Expect**

  * Pane prints `ORG_TEST=1`
  * ESC ACK works; Ctrl+C exits immediately
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 7. tmux • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **Typing** must not crash the app (regression test from ESC/Ctrl+C fixes)
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 8. tmux • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * No extra containers spawned when not intended (depending on your launcher policy)

* [ ] PASS

---

## Add-on checks (tick if relevant to your PR)

* [ ] **ESC ack** works in console & tmux (no double-ACK, no freeze)
* [ ] **Ctrl+C** exits with code 130
* [ ] All step artifacts exist (`.org/runs/<id>/steps/step-*.{out,err,meta.json}`)
* [ ] No “sticky runner” surprises: `/work/.org/org-step.sh` is a fresh copy if the script changed
* [ ] CI logs contain no “posix\_spawn 'bash' ENOENT” or uncaught exceptions

---

## How to use this locally

* Run each command and tick the checkbox.
* If a tmux test fails, open `.org/logs/tmux-*.log` for the run and attach to your PR.
* If a console test fails, attach `.org/logs/*` and the newest `.org/runs/<id>/steps/` files.


