### PR TITLE
Harden network

### DIFF
--- a/.org/config/org.lima.yaml
+++ b/.org/config/org.lima.yaml
@@ -57,47 +57,55 @@ provision:
       chmod 0440 /etc/sudoers.d/90-{{.User}}-nopasswd
       systemctl enable --now ssh
 
-      # Create network lockdown script
+      # Create network lockdown script (allow only loopback + macOS LLM port)
       cat >/usr/local/bin/org-network-lockdown <<'LOCKDOWN_SCRIPT'
       #!/bin/bash
-      # Lock down network egress - only allow localhost access
+      # Lock down egress to: loopback + ${LMS_HOST_IP}:${LMS_HOST_PORT} (from /etc/llm-uds.env)
       set -euo pipefail
 
-      # Clear existing rules
+      # Load LLM host/port used by the UDS forwarder
+      if [ -r /etc/llm-uds.env ]; then
+        # shellcheck disable=SC1091
+        . /etc/llm-uds.env
+      else
+        echo "[lockdown] /etc/llm-uds.env missing; refusing to lock down blindly." >&2
+        exit 1
+      fi
+
+      # Sanity defaults (should already be set by provision)
+      : "${LMS_HOST_IP:=192.168.5.2}"
+      : "${LMS_HOST_PORT:=11434}"
+
+      # ----- IPv4 egress policy -----
       iptables -F OUTPUT 2>/dev/null || true
       iptables -P OUTPUT ACCEPT
 
-      # Allow loopback (localhost/127.0.0.1)
+      # Allow loopback
       iptables -A OUTPUT -o lo -j ACCEPT
 
-      # Allow traffic to Lima host (192.168.5.2)
-      iptables -A OUTPUT -d 192.168.5.2 -j ACCEPT
-
-      # Allow established connections to finish
+      # Allow established/related
       iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 
-      # Block everything else
+      # Allow ONLY TCP to the macOS LLM port
+      iptables -A OUTPUT -p tcp -d "${LMS_HOST_IP}" --dport "${LMS_HOST_PORT}" -j ACCEPT
+
+      # Reject everything else
       iptables -A OUTPUT -j REJECT --reject-with icmp-net-unreachable
 
-      echo "Network locked down - only localhost and Lima host access allowed"
+      # ----- IPv6 egress policy (deny all, allow ::1) -----
+      if command -v ip6tables >/dev/null 2>&1; then
+        ip6tables -F OUTPUT 2>/dev/null || true
+        ip6tables -P OUTPUT ACCEPT
+        ip6tables -A OUTPUT -o lo -j ACCEPT
+        ip6tables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+        ip6tables -A OUTPUT -j REJECT --reject-with icmp6-adm-prohibited
+      fi
+
+      echo "[lockdown] egress allowed only to ${LMS_HOST_IP}:${LMS_HOST_PORT} (TCP) and loopback"
       LOCKDOWN_SCRIPT
 
       chmod 755 /usr/local/bin/org-network-lockdown
 
-      # Create unlock script for system user
-      cat >/usr/local/bin/org-network-unlock <<'UNLOCK_SCRIPT'
-      #!/bin/bash
-      # Unlock network egress (system user only)
-      set -euo pipefail
-
-      # Clear lockdown rules
-      iptables -F OUTPUT 2>/dev/null || true
-      iptables -P OUTPUT ACCEPT
-
-      echo "Network unlocked - full egress restored"
-      UNLOCK_SCRIPT
-
-      chmod 700 /usr/local/bin/org-network-unlock
 
       # Make lockdown persistent across reboots
       cat >/etc/systemd/system/org-network-lockdown.service <<'SERVICE_UNIT'

--- a/orgctl
+++ b/orgctl
@@ -4,7 +4,7 @@
 # - Intel: minimal VBox shim (stub)
 
 set -euo pipefail
-VERSION="1.0.5"
+VERSION="1.0.6"
 
 # ---------- constants ----------
 ORG_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -38,12 +38,16 @@ backend(){
   fi
 }
 
+mkdir -p ~/dev/org || true
+git clone https://github.com/tjamescouch/org.git ~/dev/org >/dev/null 2>&1|| true
+
 lima_cfg() {
   local p
   for p in \
     "${ORG_LIMA_CONFIG:-}" \
     "$PWD/.org/config/org.lima.yaml" \
     "$HOME/.config/org/org.lima.yaml" \
+    "~/dev/org/.org/org.lima.yaml" \
     "$ORG_DIR/.org/config/org.lima.yaml"
   do
     [[ -n "${p:-}" && -f "$p" ]] && { echo "$p"; return; }
@@ -55,6 +59,7 @@ Searched:
   $ORG_LIMA_CONFIG
   $PWD/.org/config/org.lima.yaml
   $HOME/.config/org/org.lima.yaml
+  ~/dev/org/org.lima.yaml
   $ORG_DIR/.org/config/org.lima.yaml
 
 Fix:
@@ -393,6 +398,7 @@ USAGE:
   orgctl quickstart [--no-tail] [--attach] [--fast] [--verbose|-v]
   orgctl vm <init|up|stop|destroy|ssh|logs>
   orgctl podman <first|start|build>
+  orgctl go                    # alias of: orgctl vm ssh
   orgctl version
 ENV:
   ORG_LIMA_CONFIG                 path to org.lima.yaml (optional)
@@ -414,6 +420,7 @@ case "${1:-}" in
   quickstart) shift; cmd_quickstart "$@";;
   vm)         shift; cmd_vm "$@";;
   podman)     shift; cmd_podman "$@";;
+  go)         shift; cmd_vm ssh "$@";;    # <— alias: orgctl go == orgctl vm ssh
   version)    echo "$VERSION";;
   ""|help|-h|--help) usage;;
   *) usage; exit 1;;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-multiagent-proto",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Description
< Enter a description >


## PR Checklist: Sandbox Matrix (8/8 must pass)

> **Pre-flight once per branch**
>
> ```bash
> # make sure the image exists
> ./create-container.sh     # or ./install.sh
>
> # start clean (optional but recommended)
> rm -rf .org/runs .org/logs
> ```
>
> All commands below assume the repo root. Replace `<CMD>` with the command you want the step to run.
> For “env propagation” checks we use `printenv | grep -E '^ORG_TEST=' || echo missing`.

### Legend

* **UI**: `--ui console` or `--ui tmux`
* **Mode**:

  * **non-interactive** → one step, captured output (uses `sandboxedSh`)
  * **interactive** → one interactive step (uses `shInteractive`)
* **Backend**:

  * **none** → no nested container; run directly in the app container
  * **podman** → nested container runner

---

### ✅ 1. console • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * `.org/logs/*` has no “posix\_spawn 'bash'” errors

* [ ] PASS

---

### ✅ 2. console • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * A single container session reused across steps (check `podman ps` name is stable)

* [ ] PASS

---

### ✅ 3. console • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

  > If your prompt driver doesn’t support the `interactive` keyword, trigger an interactive step via the UI or your testing harness; the key is to exercise `shInteractive`.

* **Expect**

  * Output contains `ORG_TEST=1`
  * **No** “posix\_spawn 'bash' ENOENT” anywhere

* [ ] PASS

---

### ✅ 4. console • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * Still only **one** container for the app and **one** nested podman for the step (if you keep nesting enabled); or none if your launcher sets `ORG_SANDBOX_BACKEND=none`

* [ ] PASS

---

### ✅ 5. tmux • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the tmux pane, run:

  ```
  run `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **ESC** emits the ACK and exits gracefully
  * **Ctrl+C** exits immediately (130)

* [ ] PASS

---

### ✅ 6. tmux • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane, run the same `printenv` step.

* **Expect**

  * Pane prints `ORG_TEST=1`
  * ESC ACK works; Ctrl+C exits immediately
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 7. tmux • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **Typing** must not crash the app (regression test from ESC/Ctrl+C fixes)
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 8. tmux • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * No extra containers spawned when not intended (depending on your launcher policy)

* [ ] PASS

---

## Add-on checks (tick if relevant to your PR)

* [ ] **ESC ack** works in console & tmux (no double-ACK, no freeze)
* [ ] **Ctrl+C** exits with code 130
* [ ] All step artifacts exist (`.org/runs/<id>/steps/step-*.{out,err,meta.json}`)
* [ ] No “sticky runner” surprises: `/work/.org/org-step.sh` is a fresh copy if the script changed
* [ ] CI logs contain no “posix\_spawn 'bash' ENOENT” or uncaught exceptions

---

## How to use this locally

* Run each command and tick the checkbox.
* If a tmux test fails, open `.org/logs/tmux-*.log` for the run and attach to your PR.
* If a console test fails, attach `.org/logs/*` and the newest `.org/runs/<id>/steps/` files.


