### PR TITLE
Orgctl

### DIFF
--- a/orgctl
+++ b/orgctl
@@ -4,7 +4,7 @@
 # - Intel: minimal VBox shim (stub)
 
 set -euo pipefail
-VERSION="1.0.6"
+VERSION="1.0.7"
 
 # ---------- constants ----------
 ORG_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/orgctl
+++ b/orgctl
@@ -38,8 +38,6 @@ backend(){
   fi
 }
 
-mkdir -p ~/dev/org || true
-git clone https://github.com/tjamescouch/org.git ~/dev/org >/dev/null 2>&1|| true
 
 lima_cfg() {
   local p
@@ -47,7 +45,7 @@ lima_cfg() {
     "${ORG_LIMA_CONFIG:-}" \
     "$PWD/.org/config/org.lima.yaml" \
     "$HOME/.config/org/org.lima.yaml" \
-    "~/dev/org/.org/org.lima.yaml" \
+    "~/dev/org/.org/config/org.lima.yaml" \
     "$ORG_DIR/.org/config/org.lima.yaml"
   do
     [[ -n "${p:-}" && -f "$p" ]] && { echo "$p"; return; }
@@ -59,7 +57,7 @@ Searched:
   $ORG_LIMA_CONFIG
   $PWD/.org/config/org.lima.yaml
   $HOME/.config/org/org.lima.yaml
-  ~/dev/org/org.lima.yaml
+  ~/dev/org/.org/config/org.lima.yaml
   $ORG_DIR/.org/config/org.lima.yaml
 
 Fix:
@@ -318,6 +316,9 @@ cmd_quickstart() {
       *) die "Unknown option: $1";;
     esac
   done
+
+  mkdir -p ~/dev/org || true
+  git clone https://github.com/tjamescouch/org.git || true
 
   if [[ "$(backend)" != "lima" ]]; then
     die "quickstart is for Apple Silicon (Lima)."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mini-multiagent-proto",
-  "version": "1.0.6",
+  "name": "org",
+  "version": "1.0.7",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Description
< Enter a description >


## PR Checklist: Sandbox Matrix (8/8 must pass)

> **Pre-flight once per branch**
>
> ```bash
> # make sure the image exists
> ./create-container.sh     # or ./install.sh
>
> # start clean (optional but recommended)
> rm -rf .org/runs .org/logs
> ```
>
> All commands below assume the repo root. Replace `<CMD>` with the command you want the step to run.
> For “env propagation” checks we use `printenv | grep -E '^ORG_TEST=' || echo missing`.

### Legend

* **UI**: `--ui console` or `--ui tmux`
* **Mode**:

  * **non-interactive** → one step, captured output (uses `sandboxedSh`)
  * **interactive** → one interactive step (uses `shInteractive`)
* **Backend**:

  * **none** → no nested container; run directly in the app container
  * **podman** → nested container runner

---

### ✅ 1. console • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * `.org/logs/*` has no “posix\_spawn 'bash'” errors

* [ ] PASS

---

### ✅ 2. console • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * A single container session reused across steps (check `podman ps` name is stable)

* [ ] PASS

---

### ✅ 3. console • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

  > If your prompt driver doesn’t support the `interactive` keyword, trigger an interactive step via the UI or your testing harness; the key is to exercise `shInteractive`.

* **Expect**

  * Output contains `ORG_TEST=1`
  * **No** “posix\_spawn 'bash' ENOENT” anywhere

* [ ] PASS

---

### ✅ 4. console • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * Still only **one** container for the app and **one** nested podman for the step (if you keep nesting enabled); or none if your launcher sets `ORG_SANDBOX_BACKEND=none`

* [ ] PASS

---

### ✅ 5. tmux • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the tmux pane, run:

  ```
  run `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **ESC** emits the ACK and exits gracefully
  * **Ctrl+C** exits immediately (130)

* [ ] PASS

---

### ✅ 6. tmux • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane, run the same `printenv` step.

* **Expect**

  * Pane prints `ORG_TEST=1`
  * ESC ACK works; Ctrl+C exits immediately
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 7. tmux • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **Typing** must not crash the app (regression test from ESC/Ctrl+C fixes)
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 8. tmux • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * No extra containers spawned when not intended (depending on your launcher policy)

* [ ] PASS

---

## Add-on checks (tick if relevant to your PR)

* [ ] **ESC ack** works in console & tmux (no double-ACK, no freeze)
* [ ] **Ctrl+C** exits with code 130
* [ ] All step artifacts exist (`.org/runs/<id>/steps/step-*.{out,err,meta.json}`)
* [ ] No “sticky runner” surprises: `/work/.org/org-step.sh` is a fresh copy if the script changed
* [ ] CI logs contain no “posix\_spawn 'bash' ENOENT” or uncaught exceptions

---

## How to use this locally

* Run each command and tick the checkbox.
* If a tmux test fails, open `.org/logs/tmux-*.log` for the run and attach to your PR.
* If a console test fails, attach `.org/logs/*` and the newest `.org/runs/<id>/steps/` files.


