### PR TITLE
Agent manager

### DIFF
--- a/src/agents/agent-manager.ts
+++ b/src/agents/agent-manager.ts
@@ -1,0 +1,101 @@
+import { makeStreamingOpenAiLmStudio } from "../drivers/streaming-openai-lmstudio";
+import { Agent } from "./agent";
+import { LlmAgent } from "./llm-agent";
+import { MockModel } from "./mock-model";
+
+type ModelKind = "mock" | "lmstudio";
+type AgentSpec = { id: string; kind: ModelKind; model: Agent };
+type AgentCreator = (agentId: string, model: string, extra: string, defaults: LlmDefaults) => Promise<AgentSpec>;
+type LlmDefaults =  { model: string; baseUrl: string; protocol: "openai"|"google"|"deepseek"|"antrhopic"; apiKey?: string };
+
+const openaiModelCreationHandler = async (agentId: string, model: string, extra: string, defaults: LlmDefaults): Promise<AgentSpec> => {
+    const driver = makeStreamingOpenAiLmStudio({
+        baseUrl: defaults.baseUrl,
+        model: defaults.model,
+        //apiKey: defaults.apiKey
+    });
+    const agentModel = new LlmAgent(agentId, driver, defaults.model);
+    await agentModel.load();
+
+    return {
+        id: agentId,
+        kind: "lmstudio",
+        model: agentModel,
+    };
+};
+
+const gemmaModelCreationHandler = async (agentId: string, model: string, extra: string, defaults: LlmDefaults): Promise<AgentSpec> => {
+    const driver = makeStreamingOpenAiLmStudio({ //Same for now
+        baseUrl: defaults.baseUrl,
+        model: defaults.model,
+        //apiKey: defaults.apiKey
+    });
+    const agentModel = new LlmAgent(agentId, driver, defaults.model);
+    await agentModel.load();
+
+    return {
+        id: agentId,
+        kind: "lmstudio",
+        model: agentModel,
+    };
+};
+
+const mockModelCreationHanlder = async (agentId: string, model: string, extra: string, defaults: LlmDefaults): Promise<AgentSpec> => {
+    const agentModel = new MockModel(agentId);
+    return {
+        id: agentId,
+        kind: "mock",
+        model: agentModel,
+    };
+};
+
+export class AgentManger {
+    private agents: Agent[] = [];
+
+    private readonly creationHandlers: Record<string, AgentCreator> = {
+        ['ollama.openai']: openaiModelCreationHandler,
+        ['lmstudio.openai']: openaiModelCreationHandler,
+        ['lmstudio.gemma']: gemmaModelCreationHandler,
+        ['ollama.gemma']: gemmaModelCreationHandler,
+        ['mock.mock']: mockModelCreationHanlder,
+    };
+
+    async parse(
+        spec: string,
+        llmDefaults: LlmDefaults,
+        recipeSystemPrompt?: string | null
+    ): Promise<AgentSpec[]> {
+        const list = String(spec).split(",").map(x => x.trim()).filter(Boolean);
+        const out: AgentSpec[] = [];
+        for (const item of list) {
+            const [id, kindRaw = "mock"] = item.split(":");
+            const [kind, protocolRaw ]= ((kindRaw as ModelKind) || "ollama.openai").split(".");
+            const protocol = protocolRaw || llmDefaults.protocol;
+
+            const creationHandler = this.creationHandlers[kind + '.' + protocol];
+
+            if (!creationHandler) {
+                throw new Error('Unsupported model protocol');
+            }
+
+            if (llmDefaults.protocol !== "openai") throw new Error(`Unsupported protocol: ${llmDefaults.protocol}`);
+
+            const model = llmDefaults.model;
+            const agentSpec = await creationHandler(id, model, "", llmDefaults);
+            const agentModel = agentSpec.model;
+
+            if (recipeSystemPrompt && (agentModel as { setSystemPrompt?: (s: string) => void }).setSystemPrompt) {
+                (agentModel as unknown as { setSystemPrompt: (s: string) => void }).setSystemPrompt(recipeSystemPrompt); //FIXME
+            }
+
+            out.push(agentSpec);
+        }
+        return out;
+    }
+
+    async saveAll(): Promise<void>  {
+        for (const agent of this.agents) {
+            agent.save();
+        }
+    }
+}

--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -36,4 +36,7 @@ export abstract class Agent {
     const anyGuard: any = this.guard as any;
     return typeof anyGuard.onIdle === 'function' ? anyGuard.onIdle(state) : null;
   }
+
+  abstract load(): Promise<void>;
+  abstract save(): Promise<void>;
 }

--- a/src/agents/llm-agent.ts
+++ b/src/agents/llm-agent.ts
@@ -118,6 +118,14 @@ export class LlmAgent extends Agent {
     this.toolExecutor = new StandardToolExecutor();
   }
 
+  async load(): Promise<void>{
+    this.memory.load();
+  }
+
+  async save(): Promise<void>{
+    this.memory.save();
+  }
+
   /**
    * Respond to a prompt.
    * - Add the user's text to memory.

--- a/src/memory/agent-memory.ts
+++ b/src/memory/agent-memory.ts
@@ -11,18 +11,24 @@ export abstract class AgentMemory {
   private summarizing = false;
   private pending = false;
 
+
   constructor(systemPrompt?: string) {
     if (systemPrompt && systemPrompt.trim().length > 0) {
       this.messagesBuffer.push({ role: "system", content: systemPrompt, from: "System" });
     }
   }
 
+  abstract load(): Promise<void>;
+  abstract save(): Promise<void>;
+
   async add(msg: ChatMessage): Promise<void> {
+    this.load();
     this.messagesBuffer.push(msg);
     await this.onAfterAdd();
   }
 
   async addIfNotExists(msg: ChatMessage): Promise<void> {
+    this.load();
     const exists = this.messagesBuffer.some(m => (m.content===msg.content && m.role === msg.role));
     if(!exists) {
       this.messagesBuffer.push(msg);

--- a/src/memory/dynamic-advanced-memory.ts
+++ b/src/memory/dynamic-advanced-memory.ts
@@ -123,7 +123,7 @@ export class DynamicAdvancedMemory extends AgentMemory {
     this.keepRecentTools   = Math.max(0, Math.floor(args.keepRecentTools ?? 3));
 
     // v2 persona defaults (env can override dynMode)
-    const envMode = (R?.env?.ORG_DYNAMIC_MEMORY) || "";
+    const envMode = (R.env?.ORG_DYNAMIC_MEMORY) || "";
     const mode: "off" | "shadow" | "auto" =
       args.dynMode ?? ((envMode === "off" || envMode === "shadow" || envMode === "auto") ? envMode : "shadow");
     this.dynMode = mode;

--- a/src/memory/dynamic-advanced-memory.ts
+++ b/src/memory/dynamic-advanced-memory.ts
@@ -1,5 +1,9 @@
 import type { ChatDriver, ChatMessage } from "../drivers/types";
+import { R } from "../runtime/runtime";
 import { AgentMemory } from "./agent-memory";
+import { MemoryPersisitence } from "./memory-persistence";
+import path from 'path';
+
 
 /**
  * DynamicAdvancedMemory (v2)
@@ -23,6 +27,14 @@ import { AgentMemory } from "./agent-memory";
  * - Reflection is time-based, not keyword-triggered (language-agnostic).
  * - Default: every 3 turns (min gap), window-capped; single LLM call per pass.
  */
+
+
+type PersistedState = { 
+  version: number; 
+  persona: unknown; 
+  ledger: unknown;
+  messagesBuffer: any[];
+};
 
 export class DynamicAdvancedMemory extends AgentMemory {
   private readonly driver: ChatDriver;
@@ -51,6 +63,7 @@ export class DynamicAdvancedMemory extends AgentMemory {
   private readonly decayPerPass: number;             // default 0.03 (3%)
   private readonly minKeepWeight: number;            // default 0.22
   private readonly mergeAggressiveness: number;      // default 0.60 (how strongly new evidence bumps)
+  private readonly store:MemoryPersisitence<PersistedState>;
 
   private turnCounter = 0;
   private lastReflectTurn = 0;
@@ -64,7 +77,8 @@ export class DynamicAdvancedMemory extends AgentMemory {
     languages: []
   };
 
-  private readonly ledger: PersonaEvent[] = [];
+  private ledger: PersonaEvent[] = [];
+
 
   constructor(args: {
     driver: ChatDriver;
@@ -109,7 +123,7 @@ export class DynamicAdvancedMemory extends AgentMemory {
     this.keepRecentTools   = Math.max(0, Math.floor(args.keepRecentTools ?? 3));
 
     // v2 persona defaults (env can override dynMode)
-    const envMode = (typeof process !== "undefined" && process?.env?.ORG_DYNAMIC_MEMORY) || "";
+    const envMode = (R?.env?.ORG_DYNAMIC_MEMORY) || "";
     const mode: "off" | "shadow" | "auto" =
       args.dynMode ?? ((envMode === "off" || envMode === "shadow" || envMode === "auto") ? envMode : "shadow");
     this.dynMode = mode;
@@ -121,6 +135,22 @@ export class DynamicAdvancedMemory extends AgentMemory {
     this.decayPerPass         = Math.min(0.15, Math.max(0.0, Number(args.decayPerPass ?? 0.03)));
     this.minKeepWeight        = Math.min(0.50, Math.max(0.05, Number(args.minKeepWeight ?? 0.22)));
     this.mergeAggressiveness  = Math.min(1.0, Math.max(0.1, Number(args.mergeAggressiveness ?? 0.60)));
+
+    this.store = new MemoryPersisitence<PersistedState>({ filePath: path.join(R.cwd(), ".orgmemories"), pretty: true });
+  }
+
+  //must be idempotent
+  async load() {
+    const prior = await this.store.load(); // PersistedState | null
+    if (prior) {
+      this.persona = prior?.persona as PersonaModel ?? {}; //FIXME - types
+      this.ledger = prior?.ledger as PersonaEvent ?? {};
+      this.messagesBuffer = prior?.messagesBuffer ?? [];
+    }
+  }
+
+  async save() {
+    await this.store.save({ version: this.persona.version, persona: this.persona, ledger: this.ledger, messagesBuffer: this.messagesBuffer });
   }
 
   // ---------------------------------------------------------------------------

--- a/src/memory/memory-persistence.ts
+++ b/src/memory/memory-persistence.ts
@@ -1,0 +1,80 @@
+// src/memory/memory-persistence.ts
+import { promises as fs } from "fs";
+import * as path from "path";
+import { R } from "../runtime/runtime";
+
+/**
+ * Generic persistence for an agent's memory state.
+ * - Default file: "<cwd>/.orgmemories"
+ * - Atomic write: write to "<file>.<ts>.tmp" then rename()
+ * - Type-safe generics: T is the serialized state shape
+ *
+ * Note: Keeping the original (misspelled) names for compatibility.
+ */
+export interface IMemoryPersisitence<T = unknown> {
+  /** Persist the entire state snapshot to disk (atomic). */
+  save(state: T): Promise<void>;
+
+  /** Load the last saved state (or null if none). */
+  load(): Promise<T | null>;
+}
+
+export class MemoryPersisitence<T = unknown> implements IMemoryPersisitence<T> {
+  private readonly filePath: string;
+  private readonly pretty: boolean;
+  private readonly atomic: boolean;
+  private readonly defaultState: T | null;
+
+  constructor(opts?: {
+    /** Target path for the JSON file (defaults to "<cwd>/.orgmemories"). */
+    filePath?: string;
+    /** Pretty-print JSON with trailing newline (defaults to false). */
+    pretty?: boolean;
+    /** Use tmp+rename atomic writes (defaults to true). */
+    atomic?: boolean;
+    /** Fallback value when the file doesn't exist or is empty (defaults to null). */
+    defaultState?: T | null;
+  }) {
+    this.filePath = path.resolve(opts?.filePath ?? path.join(R.cwd(), ".orgmemories"));
+    this.pretty = opts?.pretty ?? false;
+    this.atomic = opts?.atomic ?? true;
+    this.defaultState = opts?.defaultState ?? null;
+  }
+
+  public async save(state: T): Promise<void> {
+    Logger.info("Persisting modelstate");
+    // Fail fast if state is not JSON-serializable.
+    let payload: string;
+    try {
+      payload = this.pretty ? JSON.stringify(state, null, 2) + "\n" : JSON.stringify(state);
+    } catch (err) {
+      throw new Error(`MemoryPersisitence: state is not JSON-serializable: ${(err as Error).message}`);
+    }
+
+    // Ensure parent directory exists (in case a custom path was provided).
+    await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+
+    if (!this.atomic) {
+      await fs.writeFile(this.filePath, payload, "utf8");
+      return;
+    }
+
+    // Atomic write via tmp + rename.
+    const tmp = `${this.filePath}.${Date.now()}.tmp`;
+    await fs.writeFile(tmp, payload, "utf8");
+    await fs.rename(tmp, this.filePath);
+  }
+
+  public async load(): Promise<T | null> {
+    try {
+      const txt = await fs.readFile(this.filePath, "utf8");
+      const trimmed = txt.trim();
+      if (trimmed.length === 0) return this.defaultState;
+      return JSON.parse(trimmed) as T;
+    } catch (err: unknown) {
+      const code = (err as { code?: string })?.code;
+      if (code === "ENOENT") return this.defaultState; // no file yet
+      throw new Error(`MemoryPersisitence: failed to load ${this.filePath}: ${(err as Error).message}`);
+    }
+  }
+}

--- a/src/scheduler/random-scheduler.ts
+++ b/src/scheduler/random-scheduler.ts
@@ -312,6 +312,10 @@ All agents are idle. Provide the next concrete instruction or question.`;
     } catch (e) {
       Logger.error("Scheduler start failed.", e);
     } finally {
+      for (const agent of this.agents) {
+        agent.save();
+      }
+
       if (this.keepAlive) {
         clearInterval(this.keepAlive);
         this.keepAlive = null;
@@ -479,22 +483,3 @@ All agents are idle. Provide the next concrete instruction or question.`;
 }
 
 export default RandomScheduler;
-
-/* ------------------------- Module-level convenience ------------------------- */
-/* Kept for compatibility with any legacy imports. Prefer the runtime-owned instance. */
-
-function withCookedTTY<T>(fn: () => Promise<T> | T): Promise<T> {
-  return R.ttyController!.withCookedTTY(fn);
-}
-function withRawTTY<T>(fn: () => Promise<T> | T): Promise<T> {
-  return R.ttyController!.withRawTTY(fn);
-}
-
-// Optional compatibility: some older code stores a scheduler here.
-let _scheduler: unknown | undefined;
-function setScheduler(s: unknown): void {
-  _scheduler = s;
-}
-function getScheduler(): unknown | undefined {
-  return _scheduler;
-}

--- a/src/scheduler/types.ts
+++ b/src/scheduler/types.ts
@@ -11,11 +11,12 @@ export type ChatResponse = { message: string; toolsUsed: number };
  */
 export interface Responder {
   id: string;
+  save: () => Promise<void>;
   respond(
     messages: ChatMessage[],
     maxTools: number,
     peers: string[],
-    abortCallback: () => boolean
+    abortCallback: () => boolean,
   ): Promise<ChatResponse[]>;
   /**
    * Optional guard hook invoked by the scheduler when the system is idle.

--- a/src/tools/execution-gate.ts
+++ b/src/tools/execution-gate.ts
@@ -16,7 +16,7 @@ type GateConfig = { safe: boolean; interactive: boolean; guards?: ExecutionGuard
 export class ExecutionGate {
   private static _safe = false;
   private static _interactive = true;
-  private static _guards: ExecutionGuard[] = [new NoDangerousRm(), new NoRm(), new NoGitPush(), new NoGitCommit(), new NoGitAdd()];
+  private static _guards: ExecutionGuard[] = [new NoDangerousRm(), /*new NoRm(), */new NoGitPush(), new NoGitCommit(), new NoGitAdd()];
 
   static configure(cfg: GateConfig) {
     this._safe = Boolean(cfg.safe);


### PR DESCRIPTION
## Description
< Enter a description >


## PR Checklist: Sandbox Matrix (8/8 must pass)

> **Pre-flight once per branch**
>
> ```bash
> # make sure the image exists
> ./create-container.sh     # or ./install.sh
>
> # start clean (optional but recommended)
> rm -rf .org/runs .org/logs
> ```
>
> All commands below assume the repo root. Replace `<CMD>` with the command you want the step to run.
> For “env propagation” checks we use `printenv | grep -E '^ORG_TEST=' || echo missing`.

### Legend

* **UI**: `--ui console` or `--ui tmux`
* **Mode**:

  * **non-interactive** → one step, captured output (uses `sandboxedSh`)
  * **interactive** → one interactive step (uses `shInteractive`)
* **Backend**:

  * **none** → no nested container; run directly in the app container
  * **podman** → nested container runner

---

### ✅ 1. console • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * `.org/logs/*` has no “posix\_spawn 'bash'” errors

* [ ] PASS

---

### ✅ 2. console • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * A single container session reused across steps (check `podman ps` name is stable)

* [ ] PASS

---

### ✅ 3. console • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

  > If your prompt driver doesn’t support the `interactive` keyword, trigger an interactive step via the UI or your testing harness; the key is to exercise `shInteractive`.

* **Expect**

  * Output contains `ORG_TEST=1`
  * **No** “posix\_spawn 'bash' ENOENT” anywhere

* [ ] PASS

---

### ✅ 4. console • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * Still only **one** container for the app and **one** nested podman for the step (if you keep nesting enabled); or none if your launcher sets `ORG_SANDBOX_BACKEND=none`

* [ ] PASS

---

### ✅ 5. tmux • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the tmux pane, run:

  ```
  run `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **ESC** emits the ACK and exits gracefully
  * **Ctrl+C** exits immediately (130)

* [ ] PASS

---

### ✅ 6. tmux • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane, run the same `printenv` step.

* **Expect**

  * Pane prints `ORG_TEST=1`
  * ESC ACK works; Ctrl+C exits immediately
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 7. tmux • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **Typing** must not crash the app (regression test from ESC/Ctrl+C fixes)
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 8. tmux • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * No extra containers spawned when not intended (depending on your launcher policy)

* [ ] PASS

---

## Add-on checks (tick if relevant to your PR)

* [ ] **ESC ack** works in console & tmux (no double-ACK, no freeze)
* [ ] **Ctrl+C** exits with code 130
* [ ] All step artifacts exist (`.org/runs/<id>/steps/step-*.{out,err,meta.json}`)
* [ ] No “sticky runner” surprises: `/work/.org/org-step.sh` is a fresh copy if the script changed
* [ ] CI logs contain no “posix\_spawn 'bash' ENOENT” or uncaught exceptions

---

## How to use this locally

* Run each command and tick the checkbox.
* If a tmux test fails, open `.org/logs/tmux-*.log` for the run and attach to your PR.
* If a console test fails, attach `.org/logs/*` and the newest `.org/runs/<id>/steps/` files.


