### PR TITLE
New format for agent spec

### DIFF
--- a/src/agents/agent-manager.ts
+++ b/src/agents/agent-manager.ts
@@ -6,6 +6,7 @@ import { Agent } from "./agent";
 import { LlmAgent } from "./llm-agent";
 import { MockModel } from "./mock-model";
 import { R } from "../runtime/runtime";
+import { Logger } from "../logger";
 
 type ModelKind = "mock" | "lmstudio";
 type AgentSpec = { id: string; kind: ModelKind; model: Agent };
@@ -13,6 +14,8 @@ type AgentCreator = (agentId: string, model: string, extra: string, defaults: Ll
 type LlmDefaults = { model: string; baseUrl: string; protocol: "openai" | "google" | "deepseek" | "antrhopic"; apiKey?: string };
 
 const openaiModelCreationHandler = async (agentId: string, model: string, extra: string, defaults: LlmDefaults): Promise<AgentSpec> => {
+    Logger.debug("openai", {agentId, model, extra, defaults});
+
     const driver = makeStreamingOpenAiLmStudio({
         baseUrl: defaults.baseUrl,
         model: defaults.model,
@@ -29,6 +32,8 @@ const openaiModelCreationHandler = async (agentId: string, model: string, extra:
 };
 
 const gemmaModelCreationHandler = async (agentId: string, model: string, extra: string, defaults: LlmDefaults): Promise<AgentSpec> => {
+    Logger.debug("gemma", {agentId, model, extra, defaults});
+
     const driver = makeStreamingOpenAiLmStudio({ //Same for now
         baseUrl: defaults.baseUrl,
         model: defaults.model,

--- a/src/agents/mock-model.ts
+++ b/src/agents/mock-model.ts
@@ -1,15 +1,21 @@
 import { ChatMessage } from "../drivers/types";
+import { NoiseFilters } from "../scheduler/filters";
 import { sleep } from "../utils/sleep";
-import { Agent, AgentReply } from "./agent";
+import { Agent, AgentCallbacks, AgentReply } from "./agent";
 
 export class MockModel extends Agent {
+
+  async load(): Promise<void> { }
+
+  async save(): Promise<void> { }
+
   private turn = 0;
 
   constructor(private readonly name: string) {
     super("mock");
   }
 
-  async respond(messages: ChatMessage[], maxTools: number, _peers: string[], abortCallback: () => boolean): Promise<AgentReply[]> { 
+  async respond(messages: ChatMessage[], maxTools: number, filters: NoiseFilters, peers: Agent[], callbacks: AgentCallbacks): Promise<AgentReply[]> {
     await sleep(1000);
     const writePem = messages.some(m => m.content.match(/\.pem/i));
     if (writePem) {

--- a/src/input/passthrough.ts
+++ b/src/input/passthrough.ts
@@ -11,33 +11,16 @@
 
 import { Readable, Writable } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
+import { IScheduler } from "../scheduler/scheduler";
 
 type PTState = "idle" | "reading" | "closed";
-
-interface SchedulerLike {
-  enqueue?(item: { role: "user"; content: string }): void | Promise<void>;
-  enqueueUserText?(text: string): void | Promise<void>;
-  send?(text: string): void | Promise<void>;
-  stop?(): void | Promise<void>;
-  drain?(): void | Promise<void>;
-}
-
-interface PassthroughOptions {
-  stdin: Readable;
-  stdout: Writable;
-  scheduler?: SchedulerLike;
-  /**
-   * Optional callback invoked after stop/drain on graceful EOF.
-   */
-  finalizer?: () => void | Promise<void>;
-}
 
 class Passthrough {
   public state: PTState = "idle";
 
   private readonly stdin: Readable;
   private readonly stdout: Writable;
-  private scheduler?: SchedulerLike;
+  private scheduler?: IScheduler;
   private finalizer?: () => void | Promise<void>;
 
   private decoder = new StringDecoder("utf8");
@@ -124,13 +107,14 @@ class Passthrough {
     // Forward collected input as a single "user" message if any.
     if (payload.length > 0) {
       const s = this.scheduler;
-      try {
-        if (s?.enqueueUserText) await s.enqueueUserText(payload);
-        else if (s?.enqueue) await s.enqueue({ role: "user", content: payload });
-        else if (s?.send) await s.send(payload);
-      } catch {
-        // Ignore delivery errors; we still attempt graceful finalize below.
-      }
+      //FIXME
+      //try {
+      //  if (s?.enqueueUserText) await s.enqueueUserText(payload);
+      //  else if (s?.enqueue) await s.enqueue({ role: "user", content: payload });
+      //  else if (s?.send) await s.send(payload);
+      //} catch {
+      //  // Ignore delivery errors; we still attempt graceful finalize below.
+      //}
     }
 
     await this.close(true);

--- a/src/input/tty-controller.ts
+++ b/src/input/tty-controller.ts
@@ -22,6 +22,7 @@ import type { Writable } from "node:stream";
 import { R } from "../runtime/runtime";
 import { ESC_PRESSED_MSG, I_PRESSED_MSG } from "../constants";
 import { Logger } from "../logger";
+import { IScheduler } from "../scheduler/scheduler";
 
 /* ------------------------------ TTY primitives ----------------------------- */
 
@@ -136,7 +137,7 @@ export class TtyController {
   private onDataRef: (chunk: Buffer | string) => void;
 
   /* scheduler sink (tests introspect what was enqueued) */
-  private scheduler: SchedulerLike = {};
+  private scheduler: IScheduler = {};
 
   constructor(opts: TtyControllerOptions | TtyLike) {
     if (isTtyLike(opts)) {
@@ -182,7 +183,7 @@ export class TtyController {
   }
 
   /** hook scheduler sink (test double) */
-  setScheduler(s: SchedulerLike) {
+  setScheduler(s: IScheduler) {
     this.scheduler = s ?? {};
   }
 

--- a/src/memory/agent-memory.ts
+++ b/src/memory/agent-memory.ts
@@ -18,17 +18,15 @@ export abstract class AgentMemory {
     }
   }
 
-  abstract load(): Promise<void>;
-  abstract save(): Promise<void>;
+  abstract load(id: string): Promise<void>;
+  abstract save(id: string): Promise<void>;
 
   async add(msg: ChatMessage): Promise<void> {
-    this.load();
     this.messagesBuffer.push(msg);
     await this.onAfterAdd();
   }
 
   async addIfNotExists(msg: ChatMessage): Promise<void> {
-    this.load();
     const exists = this.messagesBuffer.some(m => (m.content===msg.content && m.role === msg.role));
     if(!exists) {
       this.messagesBuffer.push(msg);

--- a/src/memory/dynamic-advanced-memory.ts
+++ b/src/memory/dynamic-advanced-memory.ts
@@ -140,8 +140,8 @@ export class DynamicAdvancedMemory extends AgentMemory {
   }
 
   //must be idempotent
-  async load() {
-    const prior = await this.store.load(); // PersistedState | null
+  async load(id: string) {
+    const prior = await this.store.load(id); // PersistedState | null
     if (prior) {
       this.persona = prior?.persona as PersonaModel ?? {}; //FIXME - types
       this.ledger = prior?.ledger as PersonaEvent ?? {};
@@ -149,8 +149,8 @@ export class DynamicAdvancedMemory extends AgentMemory {
     }
   }
 
-  async save() {
-    await this.store.save({ version: this.persona.version, persona: this.persona, ledger: this.ledger, messagesBuffer: this.messagesBuffer });
+  async save(id: string) {
+    await this.store.save(id, { version: this.persona.version, persona: this.persona, ledger: this.ledger, messagesBuffer: this.messagesBuffer });
   }
 
   // ---------------------------------------------------------------------------

--- a/src/memory/memory-persistence.ts
+++ b/src/memory/memory-persistence.ts
@@ -5,76 +5,111 @@ import { R } from "../runtime/runtime";
 
 /**
  * Generic persistence for an agent's memory state.
- * - Default file: "<cwd>/.orgmemories"
- * - Atomic write: write to "<file>.<ts>.tmp" then rename()
- * - Type-safe generics: T is the serialized state shape
  *
- * Note: Keeping the original (misspelled) names for compatibility.
+ * Storage layout (per agent):
+ *   <cwd>/.orgmemories/memory-<id>.txt
+ *
+ * Semantics:
+ * - Atomic overwrite on save (tmp + rename).
+ * - JSON payload (optionally pretty), newline preserved if pretty.
+ *
+ * Note: Keeping the original (misspelled) class/interface names for compatibility.
  */
 export interface IMemoryPersisitence<T = unknown> {
-  /** Persist the entire state snapshot to disk (atomic). */
-  save(state: T): Promise<void>;
+  /** Persist the entire state snapshot for the given agent (atomic). */
+  save(id: string, state: T): Promise<void>;
 
-  /** Load the last saved state (or null if none). */
-  load(): Promise<T | null>;
+  /** Load the last saved state for the given agent (or null if none). */
+  load(id: string): Promise<T | null>;
 }
 
 export class MemoryPersisitence<T = unknown> implements IMemoryPersisitence<T> {
-  private readonly filePath: string;
+  /** Directory where memory files live (defaults to "<cwd>/.orgmemories"). */
+  private readonly dirPath: string;
   private readonly pretty: boolean;
   private readonly atomic: boolean;
   private readonly defaultState: T | null;
 
   constructor(opts?: {
-    /** Target path for the JSON file (defaults to "<cwd>/.orgmemories"). */
+    /**
+     * Target directory for memory files (defaults to "<cwd>/.orgmemories").
+     * For backwards compatibility, if `filePath` is provided it is treated as a directory.
+     */
+    dirPath?: string;
+    /** @deprecated Use dirPath; kept for compatibility. */
     filePath?: string;
     /** Pretty-print JSON with trailing newline (defaults to false). */
     pretty?: boolean;
     /** Use tmp+rename atomic writes (defaults to true). */
     atomic?: boolean;
-    /** Fallback value when the file doesn't exist or is empty (defaults to null). */
+    /** Fallback value when a file doesn't exist or is empty (defaults to null). */
     defaultState?: T | null;
   }) {
-    this.filePath = path.resolve(opts?.filePath ?? path.join(R.cwd(), ".orgmemories"));
+    const base = opts?.dirPath ?? opts?.filePath ?? path.join(R.cwd(), ".orgmemories");
+    this.dirPath = path.resolve(base);
     this.pretty = opts?.pretty ?? false;
     this.atomic = opts?.atomic ?? true;
     this.defaultState = opts?.defaultState ?? null;
   }
 
-  public async save(state: T): Promise<void> {
-    Logger.info("Persisting modelstate");
+  public async save(id: string, state: T): Promise<void> {
     // Fail fast if state is not JSON-serializable.
-    let payload: string;
-    try {
-      payload = this.pretty ? JSON.stringify(state, null, 2) + "\n" : JSON.stringify(state);
-    } catch (err) {
-      throw new Error(`MemoryPersisitence: state is not JSON-serializable: ${(err as Error).message}`);
-    }
+    const payload = this.serialize(state);
 
-    // Ensure parent directory exists (in case a custom path was provided).
-    await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+    // Ensure target directory exists.
+    await fs.mkdir(this.dirPath, { recursive: true });
+
+    const target = this.pathFor(id);
 
     if (!this.atomic) {
-      await fs.writeFile(this.filePath, payload, "utf8");
+      await fs.writeFile(target, payload, "utf8");
       return;
     }
 
     // Atomic write via tmp + rename.
-    const tmp = `${this.filePath}.${Date.now()}.tmp`;
+    const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
     await fs.writeFile(tmp, payload, "utf8");
-    await fs.rename(tmp, this.filePath);
+    await fs.rename(tmp, target);
   }
 
-  public async load(): Promise<T | null> {
+  public async load(id: string): Promise<T | null> {
+    const target = this.pathFor(id);
     try {
-      const txt = await fs.readFile(this.filePath, "utf8");
+      const txt = await fs.readFile(target, "utf8");
       const trimmed = txt.trim();
       if (trimmed.length === 0) return this.defaultState;
       return JSON.parse(trimmed) as T;
     } catch (err: unknown) {
       const code = (err as { code?: string })?.code;
       if (code === "ENOENT") return this.defaultState; // no file yet
-      throw new Error(`MemoryPersisitence: failed to load ${this.filePath}: ${(err as Error).message}`);
+      throw new Error(`MemoryPersisitence: failed to load ${target}: ${(err as Error).message}`);
+    }
+  }
+
+  // ---------------- internal helpers ----------------
+
+  /** Compute the on-disk path for an agent id, enforcing a safe filename. */
+  private pathFor(id: string): string {
+    const safe = this.sanitizeId(id);
+    return path.join(this.dirPath, `memory-${safe}.txt`);
+  }
+
+  /** Replace disallowed filename chars; keep readable, deterministic ids. */
+  private sanitizeId(id: string): string {
+    const cleaned = id.replace(/[^a-zA-Z0-9._-]/g, "_");
+    return cleaned.length > 0 ? cleaned : "unknown";
+  }
+
+  /** Serialize state to JSON (optionally pretty) and ensure newline iff pretty. */
+  private serialize(state: T): string {
+    try {
+      return this.pretty
+        ? JSON.stringify(state, null, 2) + "\n"
+        : JSON.stringify(state);
+    } catch (err) {
+      throw new Error(
+        `MemoryPersisitence: state is not JSON-serializable: ${(err as Error).message}`,
+      );
     }
   }
 }

--- a/src/routing/route-with-tags.ts
+++ b/src/routing/route-with-tags.ts
@@ -1,3 +1,4 @@
+import { Logger } from "../logger";
 import { Responder } from "../scheduler";
 import { createPDAStreamFilter } from "../utils/filter-passes/llm-pda-stream";
 import { TagPart } from "../utils/tag-parser";

--- a/src/scheduler/types.ts
+++ b/src/scheduler/types.ts
@@ -1,40 +1,15 @@
 import type { ISandboxSession } from "../sandbox/types";
-import type { ChatMessage } from "../types";
-import type { GuardDecision, GuardRouteKind } from "../guardrails/guardrail";
+import { Agent } from "../agents/agent";
 
 
 export type ChatResponse = { message: string; toolsUsed: number };
 
-/**
- * Minimal surface the scheduler needs from an agent implementation.
- * Keep this stable; other parts of the system (tests, UI) depend on it.
- */
-export interface Responder {
-  id: string;
-  save: () => Promise<void>;
-  respond(
-    messages: ChatMessage[],
-    maxTools: number,
-    peers: string[],
-    abortCallback: () => boolean,
-  ): Promise<ChatResponse[]>;
-  /**
-   * Optional guard hook invoked by the scheduler when the system is idle.
-   * Agents may request a user prompt or suggest a nudge.
-   */
-  guardOnIdle?: (state: { idleTicks: number; peers: string[]; queuesEmpty: boolean }) => GuardDecision | null;
-  /**
-   * Optional per-message guard hook used during @@group delivery.
-   * Can request to suppress broadcast, add a nudge, ask the user, or mute temporarily.
-   */
-  guardCheck?: (route: GuardRouteKind, content: string, peers: string[]) => GuardDecision | null;
-}
 
 export type AskUserFn = (fromAgent: string, content: string) => Promise<void>;
 
 
 export type SchedulerOptions = {
-  agents: Responder[];
+  agents: Agent[];
   maxTools: number;
   projectDir: string;
   reviewMode?: "ask" | "never" | "auto"

--- a/src/utils/debugger.ts
+++ b/src/utils/debugger.ts
@@ -1,0 +1,8 @@
+export const probe = () => {
+    try {
+        throw new Error("probing");
+    } catch (e) {
+        console.error("probed:")
+        console.error(e);
+    }
+}


### PR DESCRIPTION
## Description
< Enter a description >


## PR Checklist: Sandbox Matrix (8/8 must pass)

> **Pre-flight once per branch**
>
> ```bash
> # make sure the image exists
> ./create-container.sh     # or ./install.sh
>
> # start clean (optional but recommended)
> rm -rf .org/runs .org/logs
> ```
>
> All commands below assume the repo root. Replace `<CMD>` with the command you want the step to run.
> For “env propagation” checks we use `printenv | grep -E '^ORG_TEST=' || echo missing`.

### Legend

* **UI**: `--ui console` or `--ui tmux`
* **Mode**:

  * **non-interactive** → one step, captured output (uses `sandboxedSh`)
  * **interactive** → one interactive step (uses `shInteractive`)
* **Backend**:

  * **none** → no nested container; run directly in the app container
  * **podman** → nested container runner

---

### ✅ 1. console • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * `.org/logs/*` has no “posix\_spawn 'bash'” errors

* [ ] PASS

---

### ✅ 2. console • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * A single container session reused across steps (check `podman ps` name is stable)

* [ ] PASS

---

### ✅ 3. console • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

  > If your prompt driver doesn’t support the `interactive` keyword, trigger an interactive step via the UI or your testing harness; the key is to exercise `shInteractive`.

* **Expect**

  * Output contains `ORG_TEST=1`
  * **No** “posix\_spawn 'bash' ENOENT” anywhere

* [ ] PASS

---

### ✅ 4. console • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * Still only **one** container for the app and **one** nested podman for the step (if you keep nesting enabled); or none if your launcher sets `ORG_SANDBOX_BACKEND=none`

* [ ] PASS

---

### ✅ 5. tmux • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the tmux pane, run:

  ```
  run `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **ESC** emits the ACK and exits gracefully
  * **Ctrl+C** exits immediately (130)

* [ ] PASS

---

### ✅ 6. tmux • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane, run the same `printenv` step.

* **Expect**

  * Pane prints `ORG_TEST=1`
  * ESC ACK works; Ctrl+C exits immediately
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 7. tmux • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **Typing** must not crash the app (regression test from ESC/Ctrl+C fixes)
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 8. tmux • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * No extra containers spawned when not intended (depending on your launcher policy)

* [ ] PASS

---

## Add-on checks (tick if relevant to your PR)

* [ ] **ESC ack** works in console & tmux (no double-ACK, no freeze)
* [ ] **Ctrl+C** exits with code 130
* [ ] All step artifacts exist (`.org/runs/<id>/steps/step-*.{out,err,meta.json}`)
* [ ] No “sticky runner” surprises: `/work/.org/org-step.sh` is a fresh copy if the script changed
* [ ] CI logs contain no “posix\_spawn 'bash' ENOENT” or uncaught exceptions

---

## How to use this locally

* Run each command and tick the checkbox.
* If a tmux test fails, open `.org/logs/tmux-*.log` for the run and attach to your PR.
* If a console test fails, attach `.org/logs/*` and the newest `.org/runs/<id>/steps/` files.


