### PR TITLE
Experiments with evolving system prompts.

### DIFF
--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -10,15 +10,11 @@ export interface AgentReply {
 }
 
 export type AgentCallbacks = {
-  onEnqueue: (to: string, msg: ChatMessage) => void;
-  onApplyGuardDecision: (agent: Agent, dec: GuardDecision) => Promise<void>;
-  onSetLastUserDMTarget: (id: string) => void;
-  onSetRespondingAgent: (id?: string) => void;
-  onAbort: () => boolean,
+  shouldAbort: () => boolean,
   onStreamStart: () => void;
   onStreamEnd: () => void | Promise<void>;
-  onAskedUser: (message: string) => Promise<void>;
   onRoute: (message: string, filters: NoiseFilters) => Promise<boolean>;
+  onRouteCompleted: (message: string, numToolsUsed: number, yieldToUser: boolean) => Promise<boolean>;
 };
 
 

--- a/src/agents/llm-agent.ts
+++ b/src/agents/llm-agent.ts
@@ -18,6 +18,7 @@ import { NoiseFilters } from "../scheduler/filters";
 function buildSystemPrompt(id: string): string {
   return [
     `You are agent "${id}". Work autonomously in the caller's current directory inside a Debian VM.`,
+    "- Do what the user asks.",
     "- DO NOT LIE",
     "- Do not pretend or hallucinate tool call results. Do not misrepresent the facts.",
     "- Do the reasonable thing. Interpret things like a normal human would.",

--- a/src/memory/dynamic-advanced-memory.ts
+++ b/src/memory/dynamic-advanced-memory.ts
@@ -2,17 +2,17 @@ import type { ChatDriver, ChatMessage } from "../drivers/types";
 import { R } from "../runtime/runtime";
 import { AgentMemory } from "./agent-memory";
 import { MemoryPersisitence } from "./memory-persistence";
-import path from 'path';
-
+import path from "path";
 
 /**
- * DynamicAdvancedMemory (v2)
+ * DynamicAdvancedMemory (v2.1)
  *
- * A backward-compatible memory with a *reflective persona*:
- * - Periodically distills recent dialogue (any language) into a compact
- *   "Dynamic Persona Block" (roles, style, heuristics, anti-goals).
- * - Appends or refreshes that block inside the FIRST system message.
- * - Keeps the original lane summarization & budgeting logic intact.
+ * What’s new (surgical changes):
+ * - System lane is now *progressively summarized into the FIRST system message*.
+ *   We refresh a [SYSTEM LANE SUMMARY] block instead of emitting a separate system summary message.
+ * - Dynamic persona mining still occurs; in mode "auto" (default), we refresh a
+ *   [DYNAMIC PERSONA BLOCK] inside the FIRST system message.
+ * - Old budgeting / lane-keep logic is preserved.
  *
  * Modes (env OR constructor):
  *   off    → no reflection, no persona block
@@ -20,18 +20,12 @@ import path from 'path';
  *   auto   → mine/merge and write the persona block (bounded, safe)
  *
  * Safety:
- * - Persona can NEVER override static policy, SAFE_MODE, tool caps, or review.
- * - No network/git enabling, no sandbox weakening—guarded in merge/render.
- *
- * Cadence:
- * - Reflection is time-based, not keyword-triggered (language-agnostic).
- * - Default: every 3 turns (min gap), window-capped; single LLM call per pass.
+ * - Persona/summary NEVER override static policy, SAFE_MODE, tool caps, or review.
  */
 
-
-type PersistedState = { 
-  version: number; 
-  persona: unknown; 
+type PersistedState = {
+  version: number;
+  persona: unknown;
   ledger: unknown;
   messagesBuffer: any[];
 };
@@ -40,30 +34,30 @@ export class DynamicAdvancedMemory extends AgentMemory {
   private readonly driver: ChatDriver;
   private readonly model: string;
 
-  // Context budgeting knobs (unchanged from AdvancedMemory defaults)
+  // Context budgeting knobs (unchanged)
   private readonly contextTokens: number;
   private readonly reserveHeaderTokens: number;
   private readonly reserveResponseTokens: number;
-  private readonly highRatio: number;     // summarize when est > highRatio * budget
-  private readonly lowRatio: number;      // compress to <= lowRatio * budget
-  private readonly summaryRatio: number;  // fraction of budget reserved for 3 lane summaries
+  private readonly highRatio: number;
+  private readonly lowRatio: number;
+  private readonly summaryRatio: number;
   private readonly avgCharsPerToken: number;
 
   // Recency knobs
-  private readonly keepRecentPerLane: number; // keep last N assistant/user/system msgs
-  private readonly keepRecentTools: number;   // keep last N tool msgs
+  private readonly keepRecentPerLane: number;
+  private readonly keepRecentTools: number;
 
   // ------------------ Reflective Persona (v2) configuration ------------------
 
   private readonly dynMode: "off" | "shadow" | "auto";
-  private readonly minReflectGapTurns: number;       // default 3
-  private readonly reflectWindowMaxMsgs: number;     // default 16 (total mixed)
-  private readonly personaTokenFraction: number;     // default 0.12 of usable budget
-  private readonly personaMaxLines: number;          // default 12
-  private readonly decayPerPass: number;             // default 0.03 (3%)
-  private readonly minKeepWeight: number;            // default 0.22
-  private readonly mergeAggressiveness: number;      // default 0.60 (how strongly new evidence bumps)
-  private readonly store:MemoryPersisitence<PersistedState>;
+  private readonly minReflectGapTurns: number;
+  private readonly reflectWindowMaxMsgs: number;
+  private readonly personaTokenFraction: number;
+  private readonly personaMaxLines: number;
+  private readonly decayPerPass: number;
+  private readonly minKeepWeight: number;
+  private readonly mergeAggressiveness: number;
+  private readonly store: MemoryPersisitence<PersistedState>;
 
   private turnCounter = 0;
   private lastReflectTurn = 0;
@@ -74,11 +68,10 @@ export class DynamicAdvancedMemory extends AgentMemory {
     style: [],
     heuristics: [],
     antigoals: [],
-    languages: []
+    languages: [],
   };
 
   private ledger: PersonaEvent[] = [];
-
 
   constructor(args: {
     driver: ChatDriver;
@@ -86,25 +79,25 @@ export class DynamicAdvancedMemory extends AgentMemory {
     systemPrompt?: string;
 
     // Context / summarization knobs (same defaults as prior class)
-    contextTokens?: number;         // default 8192
-    reserveHeaderTokens?: number;   // default 1200
+    contextTokens?: number; // default 8192
+    reserveHeaderTokens?: number; // default 1200
     reserveResponseTokens?: number; // default 800
-    highRatio?: number;             // default 0.70
-    lowRatio?: number;              // default 0.50
-    summaryRatio?: number;          // default 0.35
-    avgCharsPerToken?: number;      // default 4
-    keepRecentPerLane?: number;     // default 4
-    keepRecentTools?: number;       // default 3
+    highRatio?: number; // default 0.70
+    lowRatio?: number; // default 0.50
+    summaryRatio?: number; // default 0.35
+    avgCharsPerToken?: number; // default 4
+    keepRecentPerLane?: number; // default 4
+    keepRecentTools?: number; // default 3
 
     // v2 reflective persona knobs (all defaulted)
     dynMode?: "off" | "shadow" | "auto";
-    minReflectGapTurns?: number;       // default 3
-    reflectWindowMaxMsgs?: number;     // default 16
-    personaTokenFraction?: number;     // default 0.12
-    personaMaxLines?: number;          // default 12
-    decayPerPass?: number;             // default 0.03
-    minKeepWeight?: number;            // default 0.22
-    mergeAggressiveness?: number;      // default 0.60
+    minReflectGapTurns?: number; // default 3
+    reflectWindowMaxMsgs?: number; // default 16
+    personaTokenFraction?: number; // default 0.12
+    personaMaxLines?: number; // default 12
+    decayPerPass?: number; // default 0.03
+    minKeepWeight?: number; // default 0.22
+    mergeAggressiveness?: number; // default 0.60
   }) {
     super(args.systemPrompt);
     this.driver = args.driver;
@@ -115,42 +108,56 @@ export class DynamicAdvancedMemory extends AgentMemory {
     this.reserveHeaderTokens = Math.max(0, Math.floor(args.reserveHeaderTokens ?? 1200));
     this.reserveResponseTokens = Math.max(0, Math.floor(args.reserveResponseTokens ?? 800));
     this.highRatio = Math.min(0.95, Math.max(0.55, args.highRatio ?? 0.70));
-    this.lowRatio  = Math.min(this.highRatio - 0.05, Math.max(0.35, args.lowRatio ?? 0.50));
-    this.summaryRatio = Math.min(0.50, Math.max(0.15, args.summaryRatio ?? 0.35));
+    this.lowRatio = Math.min(this.highRatio - 0.05, Math.max(0.35, args.lowRatio ?? 0.50));
+    this.summaryRatio = Math.min(0.5, Math.max(0.15, args.summaryRatio ?? 0.35));
 
     this.avgCharsPerToken = Math.max(1.5, Number(args.avgCharsPerToken ?? 4));
     this.keepRecentPerLane = Math.max(1, Math.floor(args.keepRecentPerLane ?? 4));
-    this.keepRecentTools   = Math.max(0, Math.floor(args.keepRecentTools ?? 3));
+    this.keepRecentTools = Math.max(0, Math.floor(args.keepRecentTools ?? 3));
 
     // v2 persona defaults (env can override dynMode)
-    const envMode = (R.env?.ORG_DYNAMIC_MEMORY) || "";
-    const mode: "off" | "shadow" | "auto" =
-      args.dynMode ?? ((envMode === "off" || envMode === "shadow" || envMode === "auto") ? envMode : "shadow");
+    const envMode = R.env?.ORG_DYNAMIC_MEMORY || "";
+    const envOk = envMode === "off" || envMode === "shadow" || envMode === "auto";
+    // Default changed to "auto" so persona folds into the system head by default.
+    const mode: "off" | "shadow" | "auto" = args.dynMode ?? (envOk ? (envMode as any) : "auto");
     this.dynMode = mode;
 
-    this.minReflectGapTurns  = Math.max(1, Math.floor(args.minReflectGapTurns ?? 3));
+    this.minReflectGapTurns = Math.max(1, Math.floor(args.minReflectGapTurns ?? 3));
     this.reflectWindowMaxMsgs = Math.max(6, Math.floor(args.reflectWindowMaxMsgs ?? 16));
     this.personaTokenFraction = Math.min(0.25, Math.max(0.06, Number(args.personaTokenFraction ?? 0.12)));
-    this.personaMaxLines      = Math.max(5, Math.floor(args.personaMaxLines ?? 12));
-    this.decayPerPass         = Math.min(0.15, Math.max(0.0, Number(args.decayPerPass ?? 0.03)));
-    this.minKeepWeight        = Math.min(0.50, Math.max(0.05, Number(args.minKeepWeight ?? 0.22)));
-    this.mergeAggressiveness  = Math.min(1.0, Math.max(0.1, Number(args.mergeAggressiveness ?? 0.60)));
+    this.personaMaxLines = Math.max(5, Math.floor(args.personaMaxLines ?? 12));
+    this.decayPerPass = Math.min(0.15, Math.max(0.0, Number(args.decayPerPass ?? 0.03)));
+    this.minKeepWeight = Math.min(0.5, Math.max(0.05, Number(args.minKeepWeight ?? 0.22)));
+    this.mergeAggressiveness = Math.min(1.0, Math.max(0.1, Number(args.mergeAggressiveness ?? 0.6)));
 
-    this.store = new MemoryPersisitence<PersistedState>({ filePath: path.join(R.cwd(), ".orgmemories"), pretty: true });
+    this.store = new MemoryPersisitence<PersistedState>({
+      filePath: path.join(R.cwd(), ".orgmemories"),
+      pretty: true,
+    });
   }
 
-  //must be idempotent
+  // must be idempotent
   async load(id: string) {
     const prior = await this.store.load(id); // PersistedState | null
     if (prior) {
-      this.persona = prior?.persona as PersonaModel ?? {}; //FIXME - types
-      this.ledger = prior?.ledger as PersonaEvent ?? {};
-      this.messagesBuffer = prior?.messagesBuffer ?? [];
+      // Keep existing defaults if missing in persisted state (surgical fix)
+      const maybePersona = prior.persona as PersonaModel | undefined;
+      this.persona = maybePersona ?? this.persona;
+
+      const maybeLedger = prior.ledger as PersonaEvent[] | undefined;
+      this.ledger = Array.isArray(maybeLedger) ? maybeLedger : this.ledger;
+
+      this.messagesBuffer = Array.isArray(prior.messagesBuffer) ? prior.messagesBuffer : this.messagesBuffer;
     }
   }
 
   async save(id: string) {
-    await this.store.save(id, { version: this.persona.version, persona: this.persona, ledger: this.ledger, messagesBuffer: this.messagesBuffer });
+    await this.store.save(id, {
+      version: this.persona.version,
+      persona: this.persona,
+      ledger: this.ledger,
+      messagesBuffer: this.messagesBuffer,
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -178,29 +185,24 @@ export class DynamicAdvancedMemory extends AgentMemory {
       const estTok2 = this.estimateTokens(this.messagesBuffer);
       if (estTok2 <= Math.floor(this.highRatio * budget2)) return;
 
-      const {
-        firstSystemIndex,
-        assistant, user, system, tool, other,
-      } = this.partition();
+      const { firstSystemIndex, assistant, user, system, tool, other } = this.partition();
 
       const tailN = this.keepRecentPerLane;
 
       const olderAssistant = assistant.slice(0, Math.max(0, assistant.length - tailN));
-      const keepAssistant  = assistant.slice(Math.max(0, assistant.length - tailN));
+      const keepAssistant = assistant.slice(Math.max(0, assistant.length - tailN));
 
       const sysHead = firstSystemIndex === 0 ? [this.messagesBuffer[0]] : [];
       const remainingSystem = firstSystemIndex === 0 ? system.slice(1) : system.slice(0);
       const olderSystem = remainingSystem.slice(0, Math.max(0, remainingSystem.length - tailN));
-      const keepSystem  = remainingSystem.slice(Math.max(0, remainingSystem.length - tailN));
+      const keepSystem = remainingSystem.slice(Math.max(0, remainingSystem.length - tailN));
 
       const olderUser = user.slice(0, Math.max(0, user.length - tailN));
-      const keepUser  = user.slice(Math.max(0, user.length - tailN));
+      const keepUser = user.slice(Math.max(0, user.length - tailN));
 
       const keepTools = tool.slice(Math.max(0, tool.length - this.keepRecentTools));
 
-      const preserved: ChatMessage[] = [
-        ...sysHead, ...keepAssistant, ...keepSystem, ...keepUser, ...keepTools, ...other
-      ];
+      const preserved: ChatMessage[] = [...sysHead, ...keepAssistant, ...keepSystem, ...keepUser, ...keepTools, ...other];
       const preservedTok = this.estimateTokens(preserved);
 
       const lowTarget = Math.floor(this.lowRatio * budget2);
@@ -222,16 +224,30 @@ export class DynamicAdvancedMemory extends AgentMemory {
       const budgetS = Math.max(48, Math.floor(totalSummaryBudget * (removedCharS / removedTotal)));
       const budgetU = Math.max(48, Math.floor(totalSummaryBudget * (removedCharU / removedTotal)));
 
+      // Progressive SYSTEM summary: include prior embedded summary (if any) + olderSystem
+      let sysMessagesForSummary = olderSystem;
+      const priorSysSummary = this.extractSystemSummaryBlock();
+      if (priorSysSummary) {
+        sysMessagesForSummary = [
+          ...olderSystem,
+          { from: "System", role: "system", content: `PRIOR SYSTEM SUMMARY:\n${priorSysSummary}` } as ChatMessage,
+        ];
+      }
+
       const [sumA, sumS, sumU] = await Promise.all([
         olderAssistant.length ? this.summarizeLane("assistant", olderAssistant, budgetA) : "",
-        olderSystem.length    ? this.summarizeLane("system",    olderSystem,    budgetS) : "",
-        olderUser.length      ? this.summarizeLane("user",      olderUser,      budgetU) : "",
+        sysMessagesForSummary.length ? this.summarizeLane("system", sysMessagesForSummary, budgetS) : "",
+        olderUser.length ? this.summarizeLane("user", olderUser, budgetU) : "",
       ]);
 
+      // We embed the SYSTEM summary into the head system message (refresh block),
+      // rather than emitting a separate system summary message.
+      if (sumS) this.embedSystemSummaryBlockIntoSystemHead(sumS);
+
+      // Only assistant & user summaries are emitted as separate messages (unchanged).
       const summaries: ChatMessage[] = [];
-      if (sumA) summaries.push({ from:"Me",     role: "assistant", content: `ASSISTANT SUMMARY:\n${sumA}` });
-      if (sumS) summaries.push({ from:"System", role: "system",    content: `SYSTEM SUMMARY:\n${sumS}` });
-      if (sumU) summaries.push({ from:"Memory", role: "user",      content: `USER SUMMARY:\n${sumU}` });
+      if (sumA) summaries.push({ from: "Me", role: "assistant", content: `ASSISTANT SUMMARY:\n${sumA}` });
+      if (sumU) summaries.push({ from: "Memory", role: "user", content: `USER SUMMARY:\n${sumU}` });
 
       const rebuilt = this.ordered(summaries, sysHead, keepAssistant, keepSystem, keepUser, keepTools, other);
       this.messagesBuffer.splice(0, this.messagesBuffer.length, ...rebuilt);
@@ -256,14 +272,16 @@ export class DynamicAdvancedMemory extends AgentMemory {
 
   private async reflectAndSquashPersona(): Promise<void> {
     this.lastReflectTurn = this.turnCounter;
-
     if (this.dynMode === "off") return;
 
     const window = this.collectWindow(this.reflectWindowMaxMsgs);
     if (window.length === 0) return;
 
     // Single LLM call that infers persona deltas in ANY language.
-    const update = await this.minePersona(window, Math.floor(this.budgetTokens() * 0.10 * this.avgCharsPerToken));
+    const update = await this.minePersona(
+      window,
+      Math.floor(this.budgetTokens() * 0.1 * this.avgCharsPerToken)
+    );
     if (!update) return;
 
     // Merge + decay (language-agnostic, not rule-based).
@@ -307,8 +325,8 @@ export class DynamicAdvancedMemory extends AgentMemory {
         "would have improved prior replies prospectively (roles, tone/style, planning heuristics, anti-goals, language).",
         "Avoid prescriptive hard policies; prefer succinct, human-like self-modeling.",
         "Never propose anything that enables network/git, weakens sandbox/review, or violates safety.",
-        "Output STRICT JSON only—no prose."
-      ].join(" ")
+        "Output STRICT JSON only—no prose.",
+      ].join(" "),
     };
 
     const schema = [
@@ -322,7 +340,7 @@ export class DynamicAdvancedMemory extends AgentMemory {
       `    "antigoals":  [{"text": "...", "weight": 0.0}],`,
       `    "languages":  [{"text": "...", "weight": 0.0}]`,
       `  }`,
-      "}"
+      "}",
     ].join("\n");
 
     const usr: ChatMessage = {
@@ -334,8 +352,8 @@ export class DynamicAdvancedMemory extends AgentMemory {
         "SCHEMA:",
         schema,
         "TRANSCRIPT:",
-        acc
-      ].join("\n\n")
+        acc,
+      ].join("\n\n"),
     };
 
     const out = await this.driver.chat([sys, usr], { model: this.model });
@@ -348,10 +366,13 @@ export class DynamicAdvancedMemory extends AgentMemory {
       const p = (obj as any).persona ?? {};
       const norm = (arr: any): PersonaFacet[] =>
         Array.isArray(arr)
-          ? arr.slice(0, 12).map((x: any) => ({
-              text: String(x?.text ?? "").trim(),
-              weight: this.clamp01(Number(x?.weight ?? 0))
-            })).filter((x: PersonaFacet) => x.text.length > 0 && x.text.length <= 80)
+          ? arr
+              .slice(0, 12)
+              .map((x: any) => ({
+                text: String(x?.text ?? "").trim(),
+                weight: this.clamp01(Number(x?.weight ?? 0)),
+              }))
+              .filter((x: PersonaFacet) => x.text.length > 0 && x.text.length <= 80)
           : [];
 
       const upd: PersonaUpdate = {
@@ -362,8 +383,8 @@ export class DynamicAdvancedMemory extends AgentMemory {
           style: norm(p.style),
           heuristics: norm(p.heuristics),
           antigoals: norm(p.antigoals),
-          languages: norm(p.languages)
-        }
+          languages: norm(p.languages),
+        },
       };
       return upd;
     } catch {
@@ -375,21 +396,20 @@ export class DynamicAdvancedMemory extends AgentMemory {
   private mergePersona(update: PersonaUpdate): boolean {
     // Decay
     const decay = 1 - this.decayPerPass;
-    const aged = (xs: PersonaFacet[]) =>
-      xs.map(f => ({ ...f, weight: f.weight * decay }));
+    const aged = (xs: PersonaFacet[]) => xs.map((f) => ({ ...f, weight: f.weight * decay }));
 
     const now = this.turnCounter;
-    this.persona.roles      = aged(this.persona.roles);
-    this.persona.style      = aged(this.persona.style);
+    this.persona.roles = aged(this.persona.roles);
+    this.persona.style = aged(this.persona.style);
     this.persona.heuristics = aged(this.persona.heuristics);
-    this.persona.antigoals  = aged(this.persona.antigoals);
-    this.persona.languages  = aged(this.persona.languages);
+    this.persona.antigoals = aged(this.persona.antigoals);
+    this.persona.languages = aged(this.persona.languages);
 
-    // Merge (language-agnostic; string-equality after normalization)
+    // Merge (string-equality after normalization)
     const mergeArr = (dst: PersonaFacet[], inc: PersonaFacet[], cap: number) => {
       for (const it of inc) {
         const key = this.normKey(it.text);
-        const idx = dst.findIndex(d => this.normKey(d.text) === key);
+        const idx = dst.findIndex((d) => this.normKey(d.text) === key);
         const bump = it.weight * this.mergeAggressiveness;
         if (idx >= 0) {
           // 1 - (1 - old) * (1 - bump)
@@ -400,7 +420,7 @@ export class DynamicAdvancedMemory extends AgentMemory {
         }
       }
       // Drop very weak; keep strongest first
-      const filtered = dst.filter(d => d.weight >= this.minKeepWeight);
+      const filtered = dst.filter((d) => d.weight >= this.minKeepWeight);
       filtered.sort((a, b) => b.weight - a.weight);
       return filtered.slice(0, cap);
     };
@@ -410,15 +430,15 @@ export class DynamicAdvancedMemory extends AgentMemory {
       style: 6,
       heuristics: 8,
       antigoals: 6,
-      languages: 2
+      languages: 2,
     };
 
     const before = JSON.stringify(this.persona);
-    this.persona.roles      = mergeArr(this.persona.roles,      update.persona.roles,      caps.roles);
-    this.persona.style      = mergeArr(this.persona.style,      update.persona.style,      caps.style);
+    this.persona.roles = mergeArr(this.persona.roles, update.persona.roles, caps.roles);
+    this.persona.style = mergeArr(this.persona.style, update.persona.style, caps.style);
     this.persona.heuristics = mergeArr(this.persona.heuristics, update.persona.heuristics, caps.heuristics);
-    this.persona.antigoals  = mergeArr(this.persona.antigoals,  update.persona.antigoals,  caps.antigoals);
-    this.persona.languages  = mergeArr(this.persona.languages,  update.persona.languages,  caps.languages);
+    this.persona.antigoals = mergeArr(this.persona.antigoals, update.persona.antigoals, caps.antigoals);
+    this.persona.languages = mergeArr(this.persona.languages, update.persona.languages, caps.languages);
 
     const after = JSON.stringify(this.persona);
     if (before !== after) {
@@ -443,7 +463,7 @@ export class DynamicAdvancedMemory extends AgentMemory {
       `- Does NOT override static policy, SAFE_MODE, tool caps, or review; it only guides tone/role/heuristics.\n`;
 
     const sect = (title: string, items: PersonaFacet[]) => {
-      const xs = items.slice(0, 99).map(x => x.text);
+      const xs = items.slice(0, 99).map((x) => x.text);
       return xs.length ? `• ${title}: ${xs.join("; ")}\n` : "";
     };
 
@@ -455,13 +475,13 @@ export class DynamicAdvancedMemory extends AgentMemory {
       sect("Style & Rhythm", this.persona.style),
       sect("Decision Heuristics", this.persona.heuristics),
       sect("Soft Anti-goals", this.persona.antigoals),
-      sect("Languages", this.persona.languages)
+      sect("Languages", this.persona.languages),
     ].filter(Boolean);
 
     for (const ch of chunks) {
-      if ((header.length + body.length + ch.length) > charBudget) break;
+      if (header.length + body.length + ch.length > charBudget) break;
       body += ch;
-      lines += (ch.match(/\n/g)?.length ?? 0);
+      lines += ch.match(/\n/g)?.length ?? 0;
       if (lines >= maxLines) break;
     }
 
@@ -470,29 +490,32 @@ export class DynamicAdvancedMemory extends AgentMemory {
 
   /** Append or refresh the persona block within the first system message. */
   private embedPersonaBlockIntoSystemHead(block: string): void {
-    const idx = this.messagesBuffer.findIndex(m => m.role === "system");
-    if (idx < 0) return;
+    this.upsertTaggedBlockInSystemHead(
+      "DYNAMIC PERSONA BLOCK",
+      `\n[BEGIN DYNAMIC PERSONA BLOCK]\n`,
+      `\n[END DYNAMIC PERSONA BLOCK]\n`,
+      block
+    );
+  }
 
-    const head = this.messagesBuffer[idx];
-    const orig = this.messageContent(head);
+  /** Append or refresh the SYSTEM lane summary within the first system message (progressive). */
+  private embedSystemSummaryBlockIntoSystemHead(summary: string): void {
+    const header =
+      `SYSTEM LANE SUMMARY (progressive)\n` +
+      `- Consolidated summary of prior system instructions & updates.\n` +
+      `- Does NOT override static policy, SAFE_MODE, tool caps, or review.\n` +
+      `${summary.trim()}\n`;
+    this.upsertTaggedBlockInSystemHead(
+      "SYSTEM LANE SUMMARY",
+      `\n[BEGIN SYSTEM LANE SUMMARY]\n`,
+      `\n[END SYSTEM LANE SUMMARY]\n`,
+      header
+    );
+  }
 
-    const startTag = "\n[BEGIN DYNAMIC PERSONA BLOCK]\n";
-    const endTag   = "\n[END DYNAMIC PERSONA BLOCK]\n";
-    const payload  = `${startTag}${block}${endTag}`;
-
-    const s = orig.indexOf(startTag);
-    const e = orig.indexOf(endTag);
-    let next: string;
-
-    if (s >= 0 && e > s) {
-      next = orig.slice(0, s) + payload + orig.slice(e + endTag.length);
-    } else {
-      const sep = orig.endsWith("\n") ? "" : "\n";
-      next = `${orig}${sep}${payload}`;
-    }
-
-    (head as unknown as { content: string }).content = next;
-    this.messagesBuffer[idx] = head;
+  /** Extract current SYSTEM LANE SUMMARY text from the head system message (if present). */
+  private extractSystemSummaryBlock(): string | "" {
+    return this.extractTaggedBlockFromSystemHead(`\n[BEGIN SYSTEM LANE SUMMARY]\n`, `\n[END SYSTEM LANE SUMMARY]\n`);
   }
 
   // ---------------------------------------------------------------------------
@@ -511,7 +534,8 @@ export class DynamicAdvancedMemory extends AgentMemory {
     let c = 0;
     for (const m of msgs) {
       const s = this.messageContent(m);
-      if (m.role === "tool" && s.length > 24_000) c += 24_000; else c += s.length;
+      if (m.role === "tool" && s.length > 24_000) c += 24_000;
+      else c += s.length;
       c += 32;
     }
     return c;
@@ -520,7 +544,7 @@ export class DynamicAdvancedMemory extends AgentMemory {
   private messageContent(m: ChatMessage): string {
     const obj = m as unknown as Record<string, unknown>;
     const val = obj?.content;
-    return (typeof val === "string") ? val : String(val ?? "");
+    return typeof val === "string" ? val : String(val ?? "");
   }
 
   private partition() {
@@ -532,18 +556,28 @@ export class DynamicAdvancedMemory extends AgentMemory {
 
     for (const m of this.messagesBuffer) {
       switch (m.role) {
-        case "assistant": assistant.push(m); break;
-        case "user":      user.push(m); break;
-        case "system":    system.push(m); break;
-        case "tool":      tool.push(m); break;
-        default:          other.push(m); break;
+        case "assistant":
+          assistant.push(m);
+          break;
+        case "user":
+          user.push(m);
+          break;
+        case "system":
+          system.push(m);
+          break;
+        case "tool":
+          tool.push(m);
+          break;
+        default:
+          other.push(m);
+          break;
       }
     }
-    const firstSystemIndex = this.messagesBuffer.findIndex(x => x.role === "system");
+    const firstSystemIndex = this.messagesBuffer.findIndex((x) => x.role === "system");
     return { firstSystemIndex, assistant, user, system, tool, other };
   }
 
-  /** Build final order: [assistant-summary, system-summary, user-summary, ...chronological rest] */
+  /** Build final order: [assistant-summary, user-summary, ...chronological rest] */
   private ordered(
     summaries: ChatMessage[],
     sysHead: ChatMessage[],
@@ -551,16 +585,15 @@ export class DynamicAdvancedMemory extends AgentMemory {
     keepS: ChatMessage[],
     keepU: ChatMessage[],
     keepT: ChatMessage[],
-    other: ChatMessage[],
+    other: ChatMessage[]
   ): ChatMessage[] {
     const rest: ChatMessage[] = [];
     const keepSet = new Set([...sysHead, ...keepA, ...keepS, ...keepU, ...keepT, ...other]);
     for (const m of this.messagesBuffer) if (keepSet.has(m)) rest.push(m);
 
     const orderedSummaries = [
-      ...summaries.filter(s => s.role === "assistant"),
-      ...summaries.filter(s => s.role === "system"),
-      ...summaries.filter(s => s.role === "user"),
+      ...summaries.filter((s) => s.role === "assistant"),
+      ...summaries.filter((s) => s.role === "user"),
     ];
     return [...orderedSummaries, ...rest];
   }
@@ -575,9 +608,12 @@ export class DynamicAdvancedMemory extends AgentMemory {
 
     const header = (() => {
       switch (laneName) {
-        case "assistant": return "Summarize prior ASSISTANT replies (decisions, plans, code edits, shell commands and outcomes).";
-        case "system":    return "Summarize SYSTEM instructions (rules, goals, constraints) without changing their intent.";
-        case "user":      return "Summarize USER requests, feedback, constraints, and acceptance criteria.";
+        case "assistant":
+          return "Summarize prior ASSISTANT replies (decisions, plans, code edits, shell commands and outcomes).";
+        case "system":
+          return "Summarize SYSTEM instructions (rules, goals, constraints) without changing their intent.";
+        case "user":
+          return "Summarize USER requests, feedback, constraints, and acceptance criteria.";
       }
     })();
 
@@ -597,14 +633,14 @@ export class DynamicAdvancedMemory extends AgentMemory {
         "You are a precise summarizer.",
         "Output concise bullet points; preserve facts, tasks, file paths, commands, constraints.",
         `Hard limit: ~${approxChars} characters total.`,
-        "Avoid fluff; keep actionable details."
-      ].join(" ")
+        "Avoid fluff; keep actionable details.",
+      ].join(" "),
     };
 
     const user: ChatMessage = {
       role: "user",
       from: "User",
-      content: `${header}\n\nTranscript:\n${acc}`
+      content: `${header}\n\nTranscript:\n${acc}`,
     };
 
     const out = await this.driver.chat([sys, user], { model: this.model });
@@ -642,6 +678,49 @@ export class DynamicAdvancedMemory extends AgentMemory {
   private normKey(s: string): string {
     return s.toLowerCase().replace(/\s+/g, " ").trim();
   }
+
+  /** Replace or append a tagged block inside the head system message. */
+  private upsertTaggedBlockInSystemHead(
+    label: string,
+    startTag: string,
+    endTag: string,
+    payloadBody: string
+  ): void {
+    const idx = this.messagesBuffer.findIndex((m) => m.role === "system");
+    if (idx < 0) return;
+    const head = this.messagesBuffer[idx];
+    const orig = this.messageContent(head);
+
+    const payload = `${startTag}${payloadBody}${endTag}`;
+    const s = orig.indexOf(startTag);
+    const e = orig.indexOf(endTag);
+
+    let next: string;
+    if (s >= 0 && e > s) {
+      // Refresh in place
+      next = orig.slice(0, s) + payload + orig.slice(e + endTag.length);
+    } else {
+      const sep = orig.endsWith("\n") ? "" : "\n";
+      next = `${orig}${sep}${payload}`;
+    }
+
+    (head as unknown as { content: string }).content = next;
+    this.messagesBuffer[idx] = head;
+  }
+
+  /** Extract the raw content of a tagged block from the head system message (or ""). */
+  private extractTaggedBlockFromSystemHead(startTag: string, endTag: string): string {
+    const idx = this.messagesBuffer.findIndex((m) => m.role === "system");
+    if (idx < 0) return "";
+    const head = this.messagesBuffer[idx];
+    const orig = this.messageContent(head);
+    const s = orig.indexOf(startTag);
+    const e = orig.indexOf(endTag);
+    if (s >= 0 && e > s) {
+      return orig.slice(s + startTag.length, e).trim();
+    }
+    return "";
+  }
 }
 
 /* --------------------------------- Types ---------------------------------- */
@@ -659,8 +738,8 @@ type PersonaModel = {
 };
 
 type PersonaUpdate = {
-  friction: number;    // 0..1
-  confidence: number;  // 0..1
+  friction: number; // 0..1
+  confidence: number; // 0..1
   persona: {
     roles: PersonaFacet[];
     style: PersonaFacet[];

--- a/src/routing/route-with-tags.ts
+++ b/src/routing/route-with-tags.ts
@@ -47,9 +47,9 @@ export function routeWithTags(raw: string, agentTokens: string[]): RouteOutcome 
     }
   }
 
-  // If no delivery was produced (e.g. empty string), treat as group message
+  // Default response if the model produces nothing
   if (deliveries.length === 0) {
-    deliveries.push({ kind: "group", content: "" });
+    deliveries.push({ kind: "user", content: "@@user" });
     sawGroup = true;
   }
 


### PR DESCRIPTION
## Description
< Enter a description >


## PR Checklist: Sandbox Matrix (8/8 must pass)

> **Pre-flight once per branch**
>
> ```bash
> # make sure the image exists
> ./create-container.sh     # or ./install.sh
>
> # start clean (optional but recommended)
> rm -rf .org/runs .org/logs
> ```
>
> All commands below assume the repo root. Replace `<CMD>` with the command you want the step to run.
> For “env propagation” checks we use `printenv | grep -E '^ORG_TEST=' || echo missing`.

### Legend

* **UI**: `--ui console` or `--ui tmux`
* **Mode**:

  * **non-interactive** → one step, captured output (uses `sandboxedSh`)
  * **interactive** → one interactive step (uses `shInteractive`)
* **Backend**:

  * **none** → no nested container; run directly in the app container
  * **podman** → nested container runner

---

### ✅ 1. console • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * `.org/logs/*` has no “posix\_spawn 'bash'” errors

* [ ] PASS

---

### ✅ 2. console • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * A single container session reused across steps (check `podman ps` name is stable)

* [ ] PASS

---

### ✅ 3. console • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

  > If your prompt driver doesn’t support the `interactive` keyword, trigger an interactive step via the UI or your testing harness; the key is to exercise `shInteractive`.

* **Expect**

  * Output contains `ORG_TEST=1`
  * **No** “posix\_spawn 'bash' ENOENT” anywhere

* [ ] PASS

---

### ✅ 4. console • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * Still only **one** container for the app and **one** nested podman for the step (if you keep nesting enabled); or none if your launcher sets `ORG_SANDBOX_BACKEND=none`

* [ ] PASS

---

### ✅ 5. tmux • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the tmux pane, run:

  ```
  run `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **ESC** emits the ACK and exits gracefully
  * **Ctrl+C** exits immediately (130)

* [ ] PASS

---

### ✅ 6. tmux • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane, run the same `printenv` step.

* **Expect**

  * Pane prints `ORG_TEST=1`
  * ESC ACK works; Ctrl+C exits immediately
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 7. tmux • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **Typing** must not crash the app (regression test from ESC/Ctrl+C fixes)
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 8. tmux • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * No extra containers spawned when not intended (depending on your launcher policy)

* [ ] PASS

---

## Add-on checks (tick if relevant to your PR)

* [ ] **ESC ack** works in console & tmux (no double-ACK, no freeze)
* [ ] **Ctrl+C** exits with code 130
* [ ] All step artifacts exist (`.org/runs/<id>/steps/step-*.{out,err,meta.json}`)
* [ ] No “sticky runner” surprises: `/work/.org/org-step.sh` is a fresh copy if the script changed
* [ ] CI logs contain no “posix\_spawn 'bash' ENOENT” or uncaught exceptions

---

## How to use this locally

* Run each command and tick the checkbox.
* If a tmux test fails, open `.org/logs/tmux-*.log` for the run and attach to your PR.
* If a console test fails, attach `.org/logs/*` and the newest `.org/runs/<id>/steps/` files.


