### PR TITLE
Initial implementation of other drivers

### DIFF
--- a/src/drivers/deepseek-toolcall-parser.ts
+++ b/src/drivers/deepseek-toolcall-parser.ts
@@ -1,0 +1,241 @@
+// deepseek-toolcall-parser.ts
+// Parse DeepSeek-style tool calls emitted inside a ```json fenced block, e.g.:
+//
+//   The user requested to execute an `ls -hla` command. To fulfill this request:
+//
+//   ```json
+//   { "name": "sh", "parameters": { "cmd": "ls -hla" } }
+//   ```
+//
+// Also remains tolerant of the Gemma-style blocks (```toolcall / [TOOL_REQUEST] …```).
+// Strict JSON inside; no “fixups”.
+
+import { ChatToolCall } from "./types";
+import { randomUUID as uuid } from "node:crypto";
+
+export class ToolCallParseError extends Error {
+  constructor(
+    message: string,
+    public readonly fenceIndex: number,
+    public readonly start: number,
+    public readonly end: number,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = "ToolCallParseError";
+  }
+}
+
+export interface ParserOptions {
+  /** If true, throw on the first malformed fence; otherwise skip bad fences. Default: false. */
+  throwOnError?: boolean;
+}
+
+export class DeepseekToolcallParser {
+  private readonly throwOnError: boolean;
+
+  constructor(opts: ParserOptions = {}) {
+    this.throwOnError = !!opts.throwOnError;
+  }
+
+  /** Return all parsed tool calls from every supported block in `text`. */
+  parseAll(text: string): ChatToolCall[] {
+    const blocks = this.findToolcallBlocks(text);
+    const out: ChatToolCall[] = [];
+
+    blocks.forEach((b, i) => {
+      try {
+        const value = this.strictJsonParse(b.content.trim());
+        if (Array.isArray(value)) {
+          for (const v of value) out.push(this.coerceToolCall(v, i, b.start, b.end));
+        } else {
+          out.push(this.coerceToolCall(value, i, b.start, b.end));
+        }
+      } catch (e) {
+        if (this.throwOnError) {
+          if (e instanceof ToolCallParseError) throw e;
+          throw new ToolCallParseError("Failed to parse toolcall block JSON", i, b.start, b.end, e);
+        }
+        // skip malformed block
+      }
+    });
+
+    return out;
+  }
+
+  /** Return the first tool call found or null. */
+  parseFirst(text: string): ChatToolCall | null {
+    const all = this.parseAll(text);
+    return all.length ? all[0] : null;
+  }
+
+  // ---------- internals ----------
+
+  private strictJsonParse(s: string): unknown {
+    return JSON.parse(s) as unknown;
+  }
+
+  private isObject(x: unknown): x is Record<string, unknown> {
+    return typeof x === "object" && x !== null && !Array.isArray(x);
+  }
+
+  private getString(o: Record<string, unknown>, key: string): string | undefined {
+    const v = o[key];
+    return typeof v === "string" ? v : undefined;
+  }
+
+  private coerceToolCall(
+    v: unknown,
+    fenceIndex: number,
+    start: number,
+    end: number
+  ): ChatToolCall {
+    if (!this.isObject(v)) {
+      throw new ToolCallParseError(
+        "Toolcall JSON must be an object or array of objects",
+        fenceIndex,
+        start,
+        end
+      );
+    }
+
+    // Support both flat and OpenAI-style { function: { name, arguments } }.
+    const fnObj = this.isObject((v as Record<string, unknown>)["function"])
+      ? ((v as Record<string, unknown>)["function"] as Record<string, unknown>)
+      : undefined;
+
+    const name =
+      this.getString(v, "name") ??
+      this.getString(v, "tool") ??
+      this.getString(v, "tool_name") ??
+      (fnObj ? this.getString(fnObj, "name") : undefined);
+
+    if (!name || !name.trim()) {
+      throw new ToolCallParseError(
+        "Missing tool name (name|tool|tool_name|function.name)",
+        fenceIndex,
+        start,
+        end
+      );
+    }
+
+    const id =
+      this.getString(v, "id") ??
+      this.getString(v, "call_id") ??
+      (fnObj ? this.getString(fnObj, "id") : undefined) ??
+      uuid();
+
+    // Prefer top-level arguments, then function.arguments. Serialize to JSON string.
+    const argsCandidate =
+      (v as Record<string, unknown>)["arguments"] ??
+      (v as Record<string, unknown>)["args"] ??
+      (v as Record<string, unknown>)["parameters"] ?? // DeepSeek
+      (v as Record<string, unknown>)["input"] ??
+      (fnObj ? fnObj["arguments"] : undefined);
+
+    const argsString =
+      typeof argsCandidate === "string"
+        ? argsCandidate
+        : this.stringifyStable(argsCandidate ?? {});
+
+    const tc: ChatToolCall = {
+      id,
+      type: "function",
+      function: {
+        name: name.trim(),
+        arguments: argsString,
+      },
+    };
+
+    return tc;
+  }
+
+  private stringifyStable(v: unknown): string {
+    return JSON.stringify(v, (key, value) => {
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        const obj = value as Record<string, unknown>;
+        const sorted = Object.keys(obj)
+          .sort()
+          .reduce<Record<string, unknown>>((acc, k) => {
+            acc[k] = obj[k];
+            return acc;
+          }, {});
+        return sorted;
+      }
+      return value;
+    });
+  }
+
+  // ----- block detection: add ```json fences (DeepSeek) + keep Gemma styles -----
+
+  private findToolcallBlocks(
+    text: string
+  ): Array<{ content: string; start: number; end: number }> {
+    const blocks: Array<{ content: string; start: number; end: number }> = [];
+
+    // Openers at line start (case-insensitive):
+    //   ```json
+    //   ```tool_request|tool_call|toolcall|tool
+    //   [TOOL_REQUEST]  (also TOOL_CALL/TOOL)
+    const openRe =
+      /^(?:```[ \t]*(json|JSON|toolcall|tool_request|tool_call|tool)\]?[^\n]*\n|\[(tool_request|tool_call|tool)\][ \t]*\r?\n)/gim;
+
+    let m: RegExpExecArray | null;
+    while ((m = openRe.exec(text))) {
+      const openStart = m.index;
+      const contentStart = openRe.lastIndex;
+      const label = (m[1] ? m[1] : m[2] ? m[2] : "tool_request").toString();
+
+      const rest = text.slice(contentStart);
+
+      // Closers (earliest wins):
+      //   1) line with ``` alone
+      //   2) line with [END_<LABEL>] or [/LABEL]  (case-insensitive)
+      const closeBacktick = this.execFirst(rest, /^```[ \t]*$/gim);
+      const labelUpper = label.toUpperCase().replace(/\]$/, "");
+      const endTagRe = new RegExp(
+        String.raw`^\[(?:END_|\/)${this.escapeRe(labelUpper)}\][ \t]*$`,
+        "gim"
+      );
+      // Fallback: any [END_*] tag
+      const endAnyRe = /^\[(?:END_|\/)[A-Z0-9_]+\][ \t]*$/gim;
+
+      const closeBracketSpecific = this.execFirst(rest, endTagRe);
+      const closeBracketAny = this.execFirst(rest, endAnyRe);
+
+      const candidates = [closeBacktick, closeBracketSpecific, closeBracketAny]
+        .filter(Boolean)
+        .sort((a, b) => (a!.index < b!.index ? -1 : 1)) as Array<{
+        index: number;
+        match: string;
+      }>;
+
+      if (!candidates.length) break; // unmatched; stop scanning
+
+      const chosen = candidates[0];
+      const content = rest.slice(0, chosen.index);
+      const end = contentStart + chosen.index + chosen.match.length;
+
+      blocks.push({ content, start: openStart, end });
+
+      // Continue scanning after this block
+      openRe.lastIndex = end;
+    }
+
+    return blocks;
+  }
+
+  private execFirst(
+    s: string,
+    re: RegExp
+  ): { index: number; match: string } | null {
+    const r = new RegExp(re.source, re.flags.includes("g") ? re.flags : re.flags + "g");
+    let m: RegExpExecArray | null;
+    while ((m = r.exec(s))) return { index: m.index, match: m[0] };
+    return null;
+  }
+
+  private escapeRe(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+}

--- a/src/drivers/streaming-deepseek-no-toools-ollama.ts
+++ b/src/drivers/streaming-deepseek-no-toools-ollama.ts
@@ -1,0 +1,289 @@
+// streaming-openai-lmstudio.ts
+import { Logger } from "../logger";
+import { rateLimiter } from "../utils/rate-limiter";
+import { timedFetch } from "../utils/timed-fetch";
+import { DeepseekToolcallParser } from "./deepseek-toolcall-parser";
+
+import type { ChatDriver, ChatMessage, ChatOutput, ChatToolCall } from "./types";
+
+interface GoogleDriverConfig {
+  baseUrl: string;    // e.g. http://127.0.0.1:11434
+  model: string;
+  timeoutMs?: number; // default 2h (aligns with non-streaming driver)
+}
+
+/** Give the event loop a chance to run key handlers / UI. */
+function yieldToLoop(): Promise<void> {
+  return new Promise<void>((resolve) =>
+    typeof (globalThis as any).setImmediate === "function"
+      ? (globalThis as any).setImmediate(resolve)
+      : setTimeout(resolve, 0)
+  );
+}
+
+/** Cooperative scheduler: yield after ~1 KiB processed or ~8ms elapsed. */
+class YieldBudget {
+  private bytesSince = 0;
+  private last = Date.now();
+  constructor(
+    private readonly byteBudget = 1024,
+    private readonly msBudget = 8
+  ) { }
+  async maybe(extraBytes = 0): Promise<void> {
+    this.bytesSince += extraBytes;
+    const now = Date.now();
+    if (this.bytesSince >= this.byteBudget || (now - this.last) >= this.msBudget) {
+      this.bytesSince = 0;
+      this.last = now;
+      await yieldToLoop();
+    }
+  }
+}
+
+/**
+ * Streaming OpenAI-compatible chat driver for LM Studio / OpenAI-style endpoints.
+ * Streams tokens via optional callbacks while returning the final ChatOutput.
+ *
+ * Extra opts supported (all optional, ignored if unused):
+ *   - model?: string
+ *   - onToken?(t: string): void
+ *   - onReasoningToken?(t: string): void
+ *   - onToolCallDelta?(delta: ChatToolCall): void
+ *   - signal?: AbortSignal
+ */
+export function makeStreamingDeepseekNoToolsOllama(cfg: GoogleDriverConfig): ChatDriver {
+  const base = cfg.baseUrl.replace(/\/+$/, "");
+  const endpoint = `${base}/v1/chat/completions`;
+  const defaultTimeout = cfg.timeoutMs ?? 2 * 60 * 60 * 1000;
+
+  async function chat(messages: ChatMessage[], opts?: any): Promise<ChatOutput> {
+    const parser = new DeepseekToolcallParser();
+
+    await rateLimiter.limit("llm-ask", 1);
+    Logger.debug("streaming messages out", messages);
+
+    const controller = new AbortController();
+    const userSignal: AbortSignal | undefined = opts?.signal;
+    const linkAbort = () => controller.abort();
+    if (userSignal) {
+      if (userSignal.aborted) controller.abort();
+      else userSignal.addEventListener("abort", linkAbort, { once: true });
+    }
+    const timer = setTimeout(() => controller.abort(), defaultTimeout);
+
+    const model = opts?.model ?? cfg.model;
+
+    const onToken: ((t: string) => void) | undefined = opts?.onToken;
+    const onReasoningToken: ((t: string) => void) | undefined = opts?.onReasoningToken;
+    const onToolCallDelta: ((t: ChatToolCall) => void) | undefined = opts?.onToolCallDelta;
+
+    const t0 = Date.now();
+    const approxChars =
+      Array.isArray(messages)
+        ? messages.reduce((s, m) => s + String((m as any).content ?? "").length, 0)
+        : 0;
+
+    Logger.debug("POST /chat (stream)", {
+      model,
+      messages: Array.isArray(messages) ? messages.length : 0,
+      approxChars,
+      timeoutMs: defaultTimeout
+    });
+
+    // Base payload for google-compatible streaming
+    const payload: any = {
+      model,
+      messages,
+      stream: true
+    };
+
+    try {
+      const res = await timedFetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+        where: "driver:openai-lmstudio:stream",
+        timeoutMs: 2 * 60 * 60 * 1000
+      });
+
+      Logger.debug("resp(stream)", { status: res.status, ms: Date.now() - t0 });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`LM Studio / OpenAI chat (stream) failed (${res.status}): ${text}`);
+      }
+
+      // Some servers may fall back to non-streaming JSON despite stream:true
+      const ct = (res.headers.get("content-type") || "").toLowerCase();
+      if (!ct.includes("text/event-stream")) {
+        const data = await res.json().catch(() => ({}));
+        const choice = data?.choices?.[0];
+        const msg = choice?.message || {};
+        const content = typeof msg?.content === "string" ? msg.content : "";
+        const nativeToolCalls: ChatToolCall[] = Array.isArray(msg?.tool_calls) ? msg.tool_calls : [];
+        const structuredToolCalls: ChatToolCall[] = parser.parseAll(content);
+        if (content && onToken) onToken(content);
+        return { text: content, reasoning: msg?.reasoning || undefined, toolCalls: nativeToolCalls.concat(structuredToolCalls) };
+      }
+
+      // SSE streaming path
+      const decoder = new TextDecoder("utf-8");
+      const yb = new YieldBudget(1024, 8); // 1 KiB or 8ms
+      let buf = "";
+      let fullText = "";
+      let fullReasoning = "";
+
+      // Accumulate tool call deltas per index (OpenAI streaming format)
+      const toolByIndex = new Map<number, ChatToolCall>();
+
+      // Process one SSE event (cooperative: yields by size/time)
+      const pumpEvent = async (rawEvent: string) => {
+        // Lines typically "data: {...}" or "data: [DONE]"
+        const dataLines = rawEvent
+          .split("\n")
+          .map((l) => l.trim())
+          .filter((l) => l.startsWith("data:"))
+          .map((l) => l.replace(/^data:\s?/, ""));
+
+        if (!dataLines.length) return;
+        const joined = dataLines.join("\n").trim();
+        if (!joined || joined === "[DONE]") return;
+
+        let payload: any;
+        try {
+          payload = JSON.parse(joined);
+        } catch {
+          return; // ignore malformed
+        }
+
+        const delta = payload?.choices?.[0]?.delta;
+        if (!delta) return;
+
+        // Content tokens (may arrive as large CoT chunks; stream cooperatively)
+        if (typeof delta.content === "string" && delta.content.length) {
+          const clean = delta.content;
+          fullText += clean;
+          if (onToken) {
+            // break very large slices so UI can breathe
+            let s = delta.content;
+            while (s.length) {
+              const piece = s.slice(0, 512);
+              s = s.slice(512);
+              try { onToken(piece); } catch { /* ignore sink errors */ }
+              await yb.maybe(piece.length);
+            }
+          } else {
+            await yb.maybe(delta.content.length);
+          }
+        }
+
+        // Reasoning tokens (same cooperative strategy)
+        if (typeof delta.reasoning === "string" && delta.reasoning.length) {
+          fullReasoning += delta.reasoning;
+          if (onReasoningToken) {
+            let s = delta.reasoning;
+            while (s.length) {
+              const piece = s.slice(0, 512);
+              s = s.slice(512);
+              try { onReasoningToken(piece); } catch { /* ignore */ }
+              await yb.maybe(piece.length);
+            }
+          } else {
+            await yb.maybe(delta.reasoning.length);
+          }
+        }
+
+        // Tool call streaming (OpenAI delta for:q
+        // mat)
+        if (Array.isArray(delta.tool_calls)) {
+          for (const item of delta.tool_calls) {
+            const idx: number = typeof item?.index === "number" ? item.index : 0;
+            const prev = toolByIndex.get(idx) ?? {
+              id: "",
+              type: "function",
+              function: { name: "", arguments: "" }
+            };
+
+            const d = item?.delta ?? {};
+            if (typeof d.id === "string" && d.id) prev.id = d.id;
+            if (typeof d.type === "string" && d.type) (prev as any).type = d.type;
+
+            const f = item?.function ?? {};
+            if (typeof f.name === "string" && f.name) prev.function.name += f.name;
+            if (typeof f.arguments === "string" && f.arguments) prev.function.arguments += f.arguments;
+
+            toolByIndex.set(idx, prev);
+            if (onToolCallDelta) {
+              try { onToolCallDelta(prev); } catch { /* ignore */ }
+            }
+            await yb.maybe(64); // small budget for tool deltas
+          }
+        }
+      };
+
+      // Stream reader: WHATWG or Node stream
+      const body: any = res.body;
+
+      if (body && typeof body.getReader === "function") {
+        // WHATWG ReadableStream
+        const reader = body.getReader();
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          await yb.maybe((value as Uint8Array)?.byteLength ?? 0);
+
+          // Process complete events separated by \n\n
+          let sepIdx: number;
+          while ((sepIdx = buf.indexOf("\n\n")) !== -1) {
+            const rawEvent = buf.slice(0, sepIdx).trim();
+            buf = buf.slice(sepIdx + 2);
+            if (rawEvent) await pumpEvent(rawEvent);
+          }
+        }
+        // Drain remainder (if any)
+        if (buf.trim()) await pumpEvent(buf.trim());
+      } else if (body && typeof body[Symbol.asyncIterator] === "function") {
+        // Node.js Readable (for node-fetch/undici)
+        for await (const chunk of body as AsyncIterable<Uint8Array>) {
+          const bytes = chunk as Uint8Array;
+          buf += decoder.decode(bytes, { stream: true });
+          await yb.maybe(bytes.byteLength);
+
+          let sepIdx: number;
+          while ((sepIdx = buf.indexOf("\n\n")) !== -1) {
+            const rawEvent = buf.slice(0, sepIdx).trim();
+            buf = buf.slice(sepIdx + 2);
+            if (rawEvent) await pumpEvent(rawEvent);
+          }
+        }
+        if (buf.trim()) await pumpEvent(buf.trim());
+      } else {
+        // Last-resort fallback: try to read as text (non-streaming)
+        const txt = await res.text();
+        buf += txt;
+        const parts = buf.split("\n\n").map((s) => s.trim());
+        for (const part of parts) {
+          if (part) await pumpEvent(part);
+        }
+      }
+
+      Logger.debug("toolByIndex.entries()", toolByIndex.entries());
+      const toolCalls: ChatToolCall[] = Array.from(toolByIndex.entries())
+        .sort((a, b) => a[0] - b[0])
+        .map(([, v]) => v);
+      const structuredToolCalls: ChatToolCall[] = parser.parseAll(fullText);
+
+      return { text: fullText, reasoning: fullReasoning || undefined, toolCalls: toolCalls.concat(structuredToolCalls) };
+    } catch (e: any) {
+      if (e?.name === "AbortError") Logger.debug("timeout(stream)", { ms: defaultTimeout });
+      throw e;
+    } finally {
+      clearTimeout(timer);
+      if (userSignal) userSignal.removeEventListener("abort", linkAbort);
+    }
+  }
+
+  return { chat };
+}

--- a/src/drivers/streaming-deepseek-ollama.ts
+++ b/src/drivers/streaming-deepseek-ollama.ts
@@ -1,0 +1,296 @@
+// streaming-openai-lmstudio.ts
+import { Logger } from "../logger";
+import { rateLimiter } from "../utils/rate-limiter";
+import { timedFetch } from "../utils/timed-fetch";
+import { DeepseekToolcallParser } from "./deepseek-toolcall-parser";
+
+import type { ChatDriver, ChatMessage, ChatOutput, ChatToolCall } from "./types";
+
+interface GoogleDriverConfig {
+  baseUrl: string;    // e.g. http://127.0.0.1:11434
+  model: string;
+  timeoutMs?: number; // default 2h (aligns with non-streaming driver)
+}
+
+/** Give the event loop a chance to run key handlers / UI. */
+function yieldToLoop(): Promise<void> {
+  return new Promise<void>((resolve) =>
+    typeof (globalThis as any).setImmediate === "function"
+      ? (globalThis as any).setImmediate(resolve)
+      : setTimeout(resolve, 0)
+  );
+}
+
+/** Cooperative scheduler: yield after ~1 KiB processed or ~8ms elapsed. */
+class YieldBudget {
+  private bytesSince = 0;
+  private last = Date.now();
+  constructor(
+    private readonly byteBudget = 1024,
+    private readonly msBudget = 8
+  ) { }
+  async maybe(extraBytes = 0): Promise<void> {
+    this.bytesSince += extraBytes;
+    const now = Date.now();
+    if (this.bytesSince >= this.byteBudget || (now - this.last) >= this.msBudget) {
+      this.bytesSince = 0;
+      this.last = now;
+      await yieldToLoop();
+    }
+  }
+}
+
+/**
+ * Streaming OpenAI-compatible chat driver for LM Studio / OpenAI-style endpoints.
+ * Streams tokens via optional callbacks while returning the final ChatOutput.
+ *
+ * Extra opts supported (all optional, ignored if unused):
+ *   - model?: string
+ *   - tools?: any[]
+ *   - onToken?(t: string): void
+ *   - onReasoningToken?(t: string): void
+ *   - onToolCallDelta?(delta: ChatToolCall): void
+ *   - signal?: AbortSignal
+ */
+export function makeStreamingDeepseekOllama(cfg: GoogleDriverConfig): ChatDriver {
+  const base = cfg.baseUrl.replace(/\/+$/, "");
+  const endpoint = `${base}/v1/chat/completions`;
+  const defaultTimeout = cfg.timeoutMs ?? 2 * 60 * 60 * 1000;
+
+  async function chat(messages: ChatMessage[], opts?: any): Promise<ChatOutput> {
+    const parser = new DeepseekToolcallParser();
+
+    await rateLimiter.limit("llm-ask", 1);
+    Logger.debug("streaming messages out", messages);
+
+    const controller = new AbortController();
+    const userSignal: AbortSignal | undefined = opts?.signal;
+    const linkAbort = () => controller.abort();
+    if (userSignal) {
+      if (userSignal.aborted) controller.abort();
+      else userSignal.addEventListener("abort", linkAbort, { once: true });
+    }
+    const timer = setTimeout(() => controller.abort(), defaultTimeout);
+
+    const model = opts?.model ?? cfg.model;
+    const tools = Array.isArray(opts?.tools) && opts.tools.length ? opts.tools : undefined;
+
+    const onToken: ((t: string) => void) | undefined = opts?.onToken;
+    const onReasoningToken: ((t: string) => void) | undefined = opts?.onReasoningToken;
+    const onToolCallDelta: ((t: ChatToolCall) => void) | undefined = opts?.onToolCallDelta;
+
+    const t0 = Date.now();
+    const approxChars =
+      Array.isArray(messages)
+        ? messages.reduce((s, m) => s + String((m as any).content ?? "").length, 0)
+        : 0;
+
+    Logger.debug("POST /chat (stream)", {
+      model,
+      messages: Array.isArray(messages) ? messages.length : 0,
+      approxChars,
+      tools: tools ? tools.length : 0,
+      timeoutMs: defaultTimeout
+    });
+
+    // Base payload for google-compatible streaming
+    const payload: any = {
+      model,
+      messages,
+      stream: true
+    };
+    if (tools) {
+      payload.tools = tools;
+      payload.tool_choice = "auto";
+    }
+
+    try {
+      const res = await timedFetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+        where: "driver:openai-lmstudio:stream",
+        timeoutMs: 2 * 60 * 60 * 1000
+      });
+
+      Logger.debug("resp(stream)", { status: res.status, ms: Date.now() - t0 });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`LM Studio / OpenAI chat (stream) failed (${res.status}): ${text}`);
+      }
+
+      // Some servers may fall back to non-streaming JSON despite stream:true
+      const ct = (res.headers.get("content-type") || "").toLowerCase();
+      if (!ct.includes("text/event-stream")) {
+        const data = await res.json().catch(() => ({}));
+        const choice = data?.choices?.[0];
+        const msg = choice?.message || {};
+        const content = typeof msg?.content === "string" ? msg.content : "";
+        const nativeToolCalls: ChatToolCall[] = Array.isArray(msg?.tool_calls) ? msg.tool_calls : [];
+        const structuredToolCalls: ChatToolCall[] = parser.parseAll(content);
+        if (content && onToken) onToken(content);
+        return { text: content, reasoning: msg?.reasoning || undefined, toolCalls: nativeToolCalls.concat(structuredToolCalls) };
+      }
+
+      // SSE streaming path
+      const decoder = new TextDecoder("utf-8");
+      const yb = new YieldBudget(1024, 8); // 1 KiB or 8ms
+      let buf = "";
+      let fullText = "";
+      let fullReasoning = "";
+
+      // Accumulate tool call deltas per index (OpenAI streaming format)
+      const toolByIndex = new Map<number, ChatToolCall>();
+
+      // Process one SSE event (cooperative: yields by size/time)
+      const pumpEvent = async (rawEvent: string) => {
+        // Lines typically "data: {...}" or "data: [DONE]"
+        const dataLines = rawEvent
+          .split("\n")
+          .map((l) => l.trim())
+          .filter((l) => l.startsWith("data:"))
+          .map((l) => l.replace(/^data:\s?/, ""));
+
+        if (!dataLines.length) return;
+        const joined = dataLines.join("\n").trim();
+        if (!joined || joined === "[DONE]") return;
+
+        let payload: any;
+        try {
+          payload = JSON.parse(joined);
+        } catch {
+          return; // ignore malformed
+        }
+
+        const delta = payload?.choices?.[0]?.delta;
+        if (!delta) return;
+
+        // Content tokens (may arrive as large CoT chunks; stream cooperatively)
+        if (typeof delta.content === "string" && delta.content.length) {
+          const clean = delta.content;
+          fullText += clean;
+          if (onToken) {
+            // break very large slices so UI can breathe
+            let s = delta.content;
+            while (s.length) {
+              const piece = s.slice(0, 512);
+              s = s.slice(512);
+              try { onToken(piece); } catch { /* ignore sink errors */ }
+              await yb.maybe(piece.length);
+            }
+          } else {
+            await yb.maybe(delta.content.length);
+          }
+        }
+
+        // Reasoning tokens (same cooperative strategy)
+        if (typeof delta.reasoning === "string" && delta.reasoning.length) {
+          fullReasoning += delta.reasoning;
+          if (onReasoningToken) {
+            let s = delta.reasoning;
+            while (s.length) {
+              const piece = s.slice(0, 512);
+              s = s.slice(512);
+              try { onReasoningToken(piece); } catch { /* ignore */ }
+              await yb.maybe(piece.length);
+            }
+          } else {
+            await yb.maybe(delta.reasoning.length);
+          }
+        }
+
+        // Tool call streaming (OpenAI delta for:q
+        // mat)
+        if (Array.isArray(delta.tool_calls)) {
+          for (const item of delta.tool_calls) {
+            const idx: number = typeof item?.index === "number" ? item.index : 0;
+            const prev = toolByIndex.get(idx) ?? {
+              id: "",
+              type: "function",
+              function: { name: "", arguments: "" }
+            };
+
+            const d = item?.delta ?? {};
+            if (typeof d.id === "string" && d.id) prev.id = d.id;
+            if (typeof d.type === "string" && d.type) (prev as any).type = d.type;
+
+            const f = item?.function ?? {};
+            if (typeof f.name === "string" && f.name) prev.function.name += f.name;
+            if (typeof f.arguments === "string" && f.arguments) prev.function.arguments += f.arguments;
+
+            toolByIndex.set(idx, prev);
+            if (onToolCallDelta) {
+              try { onToolCallDelta(prev); } catch { /* ignore */ }
+            }
+            await yb.maybe(64); // small budget for tool deltas
+          }
+        }
+      };
+
+      // Stream reader: WHATWG or Node stream
+      const body: any = res.body;
+
+      if (body && typeof body.getReader === "function") {
+        // WHATWG ReadableStream
+        const reader = body.getReader();
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          await yb.maybe((value as Uint8Array)?.byteLength ?? 0);
+
+          // Process complete events separated by \n\n
+          let sepIdx: number;
+          while ((sepIdx = buf.indexOf("\n\n")) !== -1) {
+            const rawEvent = buf.slice(0, sepIdx).trim();
+            buf = buf.slice(sepIdx + 2);
+            if (rawEvent) await pumpEvent(rawEvent);
+          }
+        }
+        // Drain remainder (if any)
+        if (buf.trim()) await pumpEvent(buf.trim());
+      } else if (body && typeof body[Symbol.asyncIterator] === "function") {
+        // Node.js Readable (for node-fetch/undici)
+        for await (const chunk of body as AsyncIterable<Uint8Array>) {
+          const bytes = chunk as Uint8Array;
+          buf += decoder.decode(bytes, { stream: true });
+          await yb.maybe(bytes.byteLength);
+
+          let sepIdx: number;
+          while ((sepIdx = buf.indexOf("\n\n")) !== -1) {
+            const rawEvent = buf.slice(0, sepIdx).trim();
+            buf = buf.slice(sepIdx + 2);
+            if (rawEvent) await pumpEvent(rawEvent);
+          }
+        }
+        if (buf.trim()) await pumpEvent(buf.trim());
+      } else {
+        // Last-resort fallback: try to read as text (non-streaming)
+        const txt = await res.text();
+        buf += txt;
+        const parts = buf.split("\n\n").map((s) => s.trim());
+        for (const part of parts) {
+          if (part) await pumpEvent(part);
+        }
+      }
+
+      Logger.debug("toolByIndex.entries()", toolByIndex.entries());
+      const toolCalls: ChatToolCall[] = Array.from(toolByIndex.entries())
+        .sort((a, b) => a[0] - b[0])
+        .map(([, v]) => v);
+      const structuredToolCalls: ChatToolCall[] = parser.parseAll(fullText);
+
+      return { text: fullText, reasoning: fullReasoning || undefined, toolCalls: toolCalls.concat(structuredToolCalls) };
+    } catch (e: any) {
+      if (e?.name === "AbortError") Logger.debug("timeout(stream)", { ms: defaultTimeout });
+      throw e;
+    } finally {
+      clearTimeout(timer);
+      if (userSignal) userSignal.removeEventListener("abort", linkAbort);
+    }
+  }
+
+  return { chat };
+}


### PR DESCRIPTION
## Description
See title


## PR Checklist: Sandbox Matrix (8/8 must pass)

> **Pre-flight once per branch**
>
> ```bash
> # make sure the image exists
> ./create-container.sh     # or ./install.sh
>
> # start clean (optional but recommended)
> rm -rf .org/runs .org/logs
> ```
>
> All commands below assume the repo root. Replace `<CMD>` with the command you want the step to run.
> For “env propagation” checks we use `printenv | grep -E '^ORG_TEST=' || echo missing`.

### Legend

* **UI**: `--ui console` or `--ui tmux`
* **Mode**:

  * **non-interactive** → one step, captured output (uses `sandboxedSh`)
  * **interactive** → one interactive step (uses `shInteractive`)
* **Backend**:

  * **none** → no nested container; run directly in the app container
  * **podman** → nested container runner

---

### ✅ 1. console • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * `.org/logs/*` has no “posix\_spawn 'bash'” errors

* [ ] PASS

---

### ✅ 2. console • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * A single container session reused across steps (check `podman ps` name is stable)

* [ ] PASS

---

### ✅ 3. console • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

  > If your prompt driver doesn’t support the `interactive` keyword, trigger an interactive step via the UI or your testing harness; the key is to exercise `shInteractive`.

* **Expect**

  * Output contains `ORG_TEST=1`
  * **No** “posix\_spawn 'bash' ENOENT” anywhere

* [ ] PASS

---

### ✅ 4. console • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * Still only **one** container for the app and **one** nested podman for the step (if you keep nesting enabled); or none if your launcher sets `ORG_SANDBOX_BACKEND=none`

* [ ] PASS

---

### ✅ 5. tmux • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the tmux pane, run:

  ```
  run `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **ESC** emits the ACK and exits gracefully
  * **Ctrl+C** exits immediately (130)

* [ ] PASS

---

### ✅ 6. tmux • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane, run the same `printenv` step.

* **Expect**

  * Pane prints `ORG_TEST=1`
  * ESC ACK works; Ctrl+C exits immediately
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 7. tmux • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **Typing** must not crash the app (regression test from ESC/Ctrl+C fixes)
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 8. tmux • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * No extra containers spawned when not intended (depending on your launcher policy)

* [ ] PASS

---

## Add-on checks (tick if relevant to your PR)

* [ ] **ESC ack** works in console & tmux (no double-ACK, no freeze)
* [ ] **Ctrl+C** exits with code 130
* [ ] All step artifacts exist (`.org/runs/<id>/steps/step-*.{out,err,meta.json}`)
* [ ] No “sticky runner” surprises: `/work/.org/org-step.sh` is a fresh copy if the script changed
* [ ] CI logs contain no “posix\_spawn 'bash' ENOENT” or uncaught exceptions

---

## How to use this locally

* Run each command and tick the checkbox.
* If a tmux test fails, open `.org/logs/tmux-*.log` for the run and attach to your PR.
* If a console test fails, attach `.org/logs/*` and the newest `.org/runs/<id>/steps/` files.


