### PR TITLE
Scheduler fsm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "metrics": "bun tsx src/metrics/run-metrics.ts summarize",
     "start": "bun run src/app.ts",
     "start:node": "node --loader ts-node/esm src/app.ts",
     "test": "bun test"

--- a/src/agents/agent-manager.ts
+++ b/src/agents/agent-manager.ts
@@ -137,7 +137,7 @@ export class AgentManger {
 
             // driverKind[.protocol]
             type Protocol = LlmDefaults["protocol"];
-            const PROTOCOLS = ["openai", "google", "deepseek", "antrhopic", "deepseek-notools"] as const;
+            const PROTOCOLS = ["openai", "google", "deepseek", "anthropic", "deepseek-notools"] as const;
             const isProtocol = (p: string): p is Protocol =>
                 (PROTOCOLS as readonly string[]).includes(p);
 

--- a/src/agents/llm-agent.ts
+++ b/src/agents/llm-agent.ts
@@ -134,7 +134,7 @@ export class LlmAgent extends Agent {
 
   async respond(messages: ChatMessage[], maxTools: number, filters: NoiseFilters, peers: Agent[], callbacks: AgentCallbacks): Promise<AgentReply[]> {
     const result: AgentReply[] = [];
-    let newMessages: ChatMessage[] = [...messages];
+    let newMessages: ChatMessage[] = [...messages].reverse();
 
     let remaining = maxTools;
     let hop = 0;
@@ -169,7 +169,7 @@ export class LlmAgent extends Agent {
 
         const yieldToUser = await callbacks.onRoute(message, filters);
         if (await callbacks.onRouteCompleted(message, toolsUsed, yieldToUser)) {
-          break;
+          return result;
         }
 
         if (yieldToUser) {

--- a/src/agents/llm-agent.ts
+++ b/src/agents/llm-agent.ts
@@ -171,6 +171,10 @@ export class LlmAgent extends Agent {
         if (await callbacks.onRouteCompleted(message, toolsUsed, yieldToUser)) {
           break;
         }
+
+        if (yieldToUser) {
+          return result;
+        }
       }
 
       if (totalToolsUsed > 0) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,7 +26,7 @@ import { createFeedbackController } from "./ui/feedback";
 import { installHotkeys } from "./runtime/hotkeys";
 import { printInitCard } from "./ui/pretty";
 import { AgentManger } from "./agents/agent-manager";
-import RandomScheduler from "./scheduler/random-scheduler";
+import { FSMScheduler } from "./scheduler/fsm-scheduler";
 
 if (R.env.ORG_LAUNCHER_SCRIPT_RAN !== "1") { // TODO - safely support non-sandboxed workflows without opening up this hole.
   Logger.error(C.red("org must be launched via the org wrapper (sandbox). Refusing to run on host."));
@@ -280,7 +280,7 @@ async function main() {
 
   const reviewMode = (args["review"] ?? "ask") as "ask" | "auto" | "never";
 
-  const scheduler: IScheduler = new RandomScheduler({
+  const scheduler: IScheduler = new FSMScheduler({
     agents, //FIXME - types
     maxTools: Math.max(0, Number(args["max-tools"] ?? (recipe?.budgets?.maxTools ?? 20))),
     onAskUser: async (_: string, content: string) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,9 +17,7 @@ import { R } from "./runtime/runtime";
 import { ExecutionGate } from "./tools/execution-gate";
 import { loadConfig } from "./config/config";
 import { C, Logger } from "./logger";
-import RandomScheduler from "./scheduler/random-scheduler";
 import type { IScheduler, SchedulerLike } from "./scheduler/scheduler";
-import { LlmAgent } from "./agents/llm-agent";
 import { getRecipe } from "./recipes";
 import { sandboxMangers } from "./sandbox/session";
 import { TtyController } from "./input/tty-controller";
@@ -28,6 +26,7 @@ import { createFeedbackController } from "./ui/feedback";
 import { installHotkeys } from "./runtime/hotkeys";
 import { printInitCard } from "./ui/pretty";
 import { AgentManger } from "./agents/agent-manager";
+import RandomScheduler from "./scheduler/random-scheduler";
 
 if (R.env.ORG_LAUNCHER_SCRIPT_RAN !== "1") { // TODO - safely support non-sandboxed workflows without opening up this hole.
   Logger.error(C.red("org must be launched via the org wrapper (sandbox). Refusing to run on host."));

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,7 +26,7 @@ import { createFeedbackController } from "./ui/feedback";
 import { installHotkeys } from "./runtime/hotkeys";
 import { printInitCard } from "./ui/pretty";
 import { AgentManger } from "./agents/agent-manager";
-import { FSMScheduler } from "./scheduler/fsm-scheduler";
+import { RandomScheduler } from "./scheduler/random-scheduler";
 
 if (R.env.ORG_LAUNCHER_SCRIPT_RAN !== "1") { // TODO - safely support non-sandboxed workflows without opening up this hole.
   Logger.error(C.red("org must be launched via the org wrapper (sandbox). Refusing to run on host."));
@@ -280,8 +280,8 @@ async function main() {
 
   const reviewMode = (args["review"] ?? "ask") as "ask" | "auto" | "never";
 
-  const scheduler: IScheduler = new FSMScheduler({
-    agents, //FIXME - types
+  const scheduler: IScheduler = new RandomScheduler({
+    agents,
     maxTools: Math.max(0, Number(args["max-tools"] ?? (recipe?.budgets?.maxTools ?? 20))),
     onAskUser: async (_: string, content: string) => {
       if (R.isInteractive()) {

--- a/src/metrics/runtime-metrics.ts
+++ b/src/metrics/runtime-metrics.ts
@@ -1,0 +1,365 @@
+// src/metrics/run-metrics.ts
+// Minimal, type-safe metrics events + JSONL logger + CLI summarizer.
+// NEW: If no tool events exist, we heuristically estimate tool success by
+// scraping .orgmemories/* for tool-role messages across ALL agents.
+//
+// Usage:
+//   import { RunMetrics } from "../metrics/run-metrics";
+//   await RunMetrics.emitStep({...});   // (A) per-turn hook
+//   await RunMetrics.emitTool({...});   // (B) optional; if omitted, summarizer will estimate
+// CLI:
+//   bun tsx src/metrics/run-metrics.ts summarize [.org/metrics.jsonl]
+
+import { promises as fs } from "fs";
+import * as path from "path";
+
+export type Iso8601 = string & { __brand: "Iso8601" };
+
+export type StepEvent = {
+  kind: "step";
+  runId: string;
+  turn: number;                   // monotonically increasing per session
+  agent?: string | null;          // "alice"/"bob"/...
+  phase?: string | null;          // optional, e.g., "QA" | "Plan" | "Surgery"
+  headerTokens: number;           // tokens of head system message (P_t)
+  totalTokens: number;            // tokens of [P_t, H_t]
+  userVisibleReply?: string;      // ONLY the outward reply (omit debug/CoT)
+  coherent?: boolean;             // optional: did this step advance plan w/o invariant breaks?
+  personaVersion?: number;
+  normativeVersion?: number;
+  timestamp: Iso8601;
+};
+
+export type ToolEvent = {
+  kind: "tool";
+  runId: string;
+  turn: number;
+  tool: string;
+  ok: boolean;                    // success/failure of the tool call
+  timestamp: Iso8601;
+};
+
+export type PatchEvent = {
+  kind: "patch";
+  runId: string;
+  turn: number;
+  proposed: boolean;
+  applied?: boolean;
+  ok?: boolean;                   // true if applied cleanly and checks passed
+  timestamp: Iso8601;
+};
+
+export type PolicyConflictEvent = {
+  kind: "policy_conflict";
+  runId: string;
+  turn: number;
+  baseDirective: string;          // short label, e.g., "concise"
+  normDirective: string;          // e.g., "verbose"
+  chosen: "base" | "norm" | "user" | "other";
+  complied: boolean;              // did output match chosen?
+  timestamp: Iso8601;
+};
+
+export type ProspectiveEvent = {
+  kind: "prospective";
+  runId: string;
+  turn: number;
+  action: "scheduled" | "fired";
+  id: string;                     // your trigger id
+  timestamp: Iso8601;
+};
+
+export type UserInterjectionEvent = {
+  kind: "user_interjection";
+  runId: string;
+  turn: number;
+  timestamp: Iso8601;
+};
+
+export type MetricEvent =
+  | StepEvent
+  | ToolEvent
+  | PatchEvent
+  | PolicyConflictEvent
+  | ProspectiveEvent
+  | UserInterjectionEvent;
+
+function nowIso(): Iso8601 {
+  return new Date().toISOString() as Iso8601;
+}
+
+function bool(v: unknown): v is boolean {
+  return typeof v === "boolean";
+}
+
+function isFinitePosInt(n: unknown): n is number {
+  return Number.isFinite(n) && typeof n === "number" && n >= 0;
+}
+
+export class RunMetrics {
+  private static filePath: string | null = null;
+
+  /** Where to write JSONL. Defaults to ".org/metrics.jsonl" unless ORG_METRICS_FILE is set. */
+  static async init(fileOverride?: string): Promise<void> {
+    if (this.filePath) return;
+    const p =
+      fileOverride ||
+      process.env.ORG_METRICS_FILE ||
+      path.join(process.cwd(), ".org", "metrics.jsonl");
+    await fs.mkdir(path.dirname(p), { recursive: true });
+    this.filePath = p;
+  }
+
+  private static async write(ev: MetricEvent): Promise<void> {
+    if (!this.filePath) await this.init();
+    await fs.appendFile(this.filePath!, JSON.stringify(ev) + "\n", "utf8");
+  }
+
+  // ---- Emitters (call these from your code) ---------------------------------
+
+  static async emitStep(e: Omit<StepEvent, "kind" | "timestamp">): Promise<void> {
+    if (!isFinitePosInt(e.turn)) throw new Error("emitStep: invalid turn");
+    if (!isFinitePosInt(e.headerTokens) || !isFinitePosInt(e.totalTokens))
+      throw new Error("emitStep: invalid token counts");
+    await this.write({ kind: "step", timestamp: nowIso(), ...e });
+  }
+
+  static async emitTool(e: Omit<ToolEvent, "kind" | "timestamp">): Promise<void> {
+    await this.write({ kind: "tool", timestamp: nowIso(), ...e });
+  }
+
+  static async emitPatch(e: Omit<PatchEvent, "kind" | "timestamp">): Promise<void> {
+    await this.write({ kind: "patch", timestamp: nowIso(), ...e });
+  }
+
+  static async emitPolicyConflict(
+    e: Omit<PolicyConflictEvent, "kind" | "timestamp">
+  ): Promise<void> {
+    await this.write({ kind: "policy_conflict", timestamp: nowIso(), ...e });
+  }
+
+  static async emitProspective(
+    e: Omit<ProspectiveEvent, "kind" | "timestamp">
+  ): Promise<void> {
+    await this.write({ kind: "prospective", timestamp: nowIso(), ...e });
+  }
+
+  static async emitUserInterjection(
+    e: Omit<UserInterjectionEvent, "kind" | "timestamp">
+  ): Promise<void> {
+    await this.write({ kind: "user_interjection", timestamp: nowIso(), ...e });
+  }
+
+  // ---- Summarizer (optional CLI) -------------------------------------------
+
+  static async summarize(file?: string): Promise<void> {
+    const fp =
+      file ||
+      process.env.ORG_METRICS_FILE ||
+      path.join(process.cwd(), ".org", "metrics.jsonl");
+
+    const txt = await fs.readFile(fp, "utf8").catch(() => "");
+    const lines = txt ? txt.split(/\r?\n/).filter(Boolean) : [];
+
+    const steps: StepEvent[] = [];
+    const tools: ToolEvent[] = [];
+    const patches: PatchEvent[] = [];
+    const conflicts: PolicyConflictEvent[] = [];
+    const pros: ProspectiveEvent[] = [];
+    const userInt: UserInterjectionEvent[] = [];
+
+    for (const line of lines) {
+      try {
+        const ev = JSON.parse(line) as MetricEvent;
+        switch (ev.kind) {
+          case "step": steps.push(ev); break;
+          case "tool": tools.push(ev); break;
+          case "patch": patches.push(ev); break;
+          case "policy_conflict": conflicts.push(ev); break;
+          case "prospective": pros.push(ev); break;
+          case "user_interjection": userInt.push(ev); break;
+        }
+      } catch { /* ignore bad lines */ }
+    }
+
+    // ---- Core outcome: CSR & CSH (if coherent flags provided) ---------------
+    const coherentFlags = steps.map(s => s.coherent).filter(bool);
+    const csr = coherentFlags.length
+      ? coherentFlags.reduce((a, b) => a + (b ? 1 : 0), 0) / coherentFlags.length
+      : NaN;
+
+    const csh = Number.isFinite(csr) && csr > 0 && csr < 1
+      ? Math.log(0.5) / Math.log(csr)
+      : NaN;
+
+    // ---- Header share & planner-leak rate -----------------------------------
+    const hsSamples = steps.filter(s => s.totalTokens > 0);
+    const headerShare =
+      hsSamples.length
+        ? hsSamples.reduce((a, s) => a + s.headerTokens / s.totalTokens, 0) / hsSamples.length
+        : NaN;
+
+    const PLR_regex = /\b(?:Now produce final answer\.?|Thus final answer:?|Plan:|Two distinct lines)\b/i;
+    const plrBase = steps.filter(s => typeof s.userVisibleReply === "string");
+    const plr =
+      plrBase.length
+        ? plrBase.reduce((a, s) => a + (PLR_regex.test(s.userVisibleReply!) ? 1 : 0), 0) /
+          plrBase.length
+        : NaN;
+
+    // ---- Tool success --------------------------------------------------------
+    let toolSuccess: number = NaN;
+    let toolSuccessNote = "";
+
+    if (tools.length) {
+      toolSuccess =
+        tools.reduce((a, t) => a + (t.ok ? 1 : 0), 0) / tools.length;
+      toolSuccessNote = "from emitted tool events";
+    } else {
+      // Fallback: estimate across ALL agents by scraping .orgmemories/*
+      const est = await estimateToolSuccessFromOrgMemories(process.cwd());
+      if (est) {
+        const denom = est.ok + est.fail;
+        toolSuccess = denom > 0 ? est.ok / denom : NaN;
+        toolSuccessNote = denom > 0
+          ? `est. from .orgmemories (${est.ok} ok, ${est.fail} fail, ${est.unknown} unknown)`
+          : "no tool evidence in .orgmemories";
+      }
+    }
+
+    // ---- Patch Apply Success (if you ever emit it) ---------------------------
+    const patchProposed = patches.filter(p => p.proposed);
+    const patchApplied = patchProposed.filter(p => p.applied === true);
+    const patchOk =
+      patchApplied.length
+        ? patchApplied.reduce((a, p) => a + (p.ok ? 1 : 0), 0) / patchApplied.length
+        : NaN;
+
+    // ---- Intervention interval ----------------------------------------------
+    const userTurns = userInt.map(u => u.turn).sort((a, b) => a - b);
+    let intervals: number[] = [];
+    for (let i = 1; i < userTurns.length; i++) intervals.push(userTurns[i] - userTurns[i - 1]);
+    const medianIntervention = intervals.length
+      ? intervals.sort((a, b) => a - b)[Math.floor((intervals.length - 1) / 2)]
+      : NaN;
+
+    // ---- IAC (needs explicit conflict events) --------------------------------
+    const agree = conflicts.filter(c => c.baseDirective === c.normDirective);
+    const conflict = conflicts.filter(c => c.baseDirective !== c.normDirective);
+
+    const agreeCompliance =
+      agree.length ? agree.reduce((a, c) => a + (c.complied ? 1 : 0), 0) / agree.length : NaN;
+
+    const conflictComplianceNorm =
+      conflict.length
+        ? conflict
+            .filter(c => c.chosen === "norm")
+            .reduce((a, c) => a + (c.complied ? 1 : 0), 0) /
+          Math.max(1, conflict.filter(c => c.chosen === "norm").length)
+        : NaN;
+
+    const IAC =
+      Number.isFinite(agreeCompliance) && Number.isFinite(conflictComplianceNorm) && agreeCompliance > 0
+        ? conflictComplianceNorm / agreeCompliance
+        : NaN;
+
+    // ---- Print scoreboard ----------------------------------------------------
+    const fmt = (x: number) =>
+      Number.isFinite(x) ? (Math.abs(x) >= 1 ? x.toFixed(2) : (x * 100).toFixed(1) + "%") : "—";
+
+    console.log("\n=== org :: run metrics ===");
+    console.log("steps:", steps.length, "tools:", tools.length, "patches:", patches.length);
+    console.log("CSR:", fmt(csr), "   CSH(0.5):", fmt(csh));
+    console.log("Header share:", fmt(headerShare), "   PLR:", fmt(plr));
+    console.log("Tool success:", fmt(toolSuccess), toolSuccessNote ? `  (${toolSuccessNote})` : "");
+    console.log("Patch ok:", fmt(patchOk), "   Intervention interval (median turns):", fmt(medianIntervention));
+    console.log("IAC (Norm vs Base):", fmt(IAC));
+    console.log("==========================\n");
+  }
+}
+
+// ---- Heuristic tool estimator (no hooks; aggregates across ALL agents) -----
+
+type ToolEst = { ok: number; fail: number; unknown: number };
+
+async function estimateToolSuccessFromOrgMemories(root: string): Promise<ToolEst | null> {
+  const dir = path.join(root, ".orgmemories");
+  let files: string[] = [];
+  try {
+    files = await fs.readdir(dir);
+  } catch {
+    return null; // no memory dir
+  }
+  files = files
+    .filter(f => !f.startsWith(".") && !f.endsWith(".lock"))
+    .map(f => path.join(dir, f));
+
+  if (files.length === 0) return null;
+
+  let ok = 0, fail = 0, unknown = 0;
+
+  for (const fp of files) {
+    let txt = "";
+    try { txt = await fs.readFile(fp, "utf8"); } catch { continue; }
+    let obj: any = null;
+    try { obj = JSON.parse(txt); } catch { continue; }
+
+    const buf = Array.isArray(obj?.messagesBuffer) ? obj.messagesBuffer : [];
+    for (const m of buf) {
+      if (!m || m.role !== "tool") continue;
+
+      // Normalize content to string
+      const cVal = (m as any).content;
+      let content: string;
+      if (typeof cVal === "string") content = cVal;
+      else if (cVal != null) { try { content = JSON.stringify(cVal); } catch { content = String(cVal); } }
+      else content = "";
+
+      const verdict = classifyToolContent(content);
+      if (verdict === "ok") ok++;
+      else if (verdict === "fail") fail++;
+      else unknown++;
+    }
+  }
+  return { ok, fail, unknown };
+}
+
+type ToolOutcome = "ok" | "fail" | "unknown";
+function classifyToolContent(s: string): ToolOutcome {
+  const t = s || "";
+
+  // Try strict JSON first
+  try {
+    const obj = JSON.parse(t);
+    // Common fields in our tool envelopes
+    if (obj && typeof obj === "object") {
+      if (obj.ok === true || obj.success === true || obj.status === "ok" || obj.status === "success") return "ok";
+      if (obj.ok === false || obj.success === false || obj.error != null) return "fail";
+      if (Number.isFinite(obj.exitCode)) return obj.exitCode === 0 ? "ok" : "fail";
+    }
+  } catch { /* not JSON; fallthrough to regex */ }
+
+  // Regex heuristics for raw logs
+  if (/\b(exited?\s+with\s+code\s+0|exit\s*[:=]\s*0|exitCode\s*[:=]\s*0)\b/i.test(t)) return "ok";
+  if (/\b(exit(?:ed)?\s+with\s+code\s+[1-9]\d*|exit\s*[:=]\*[1-9]\d*|exitCode\s*[:=]\s*[1-9]\d*)\b/i.test(t)) return "fail";
+  if (/\b(error|exception|traceback|failed|non-zero exit)\b/i.test(t)) return "fail";
+
+  // Unknown if nothing conclusive found
+  return "unknown";
+}
+
+// ---- Simple CLI --------------------------------------------------------------
+if (require.main === module) {
+  (async () => {
+    const sub = process.argv[2];
+    if (sub === "summarize") {
+      const file = process.argv[3];
+      await RunMetrics.summarize(file);
+    } else {
+      console.log("Usage: bun tsx src/metrics/run-metrics.ts summarize [.org/metrics.jsonl]");
+    }
+  })().catch(err => {
+    console.error("[metrics] error:", err?.stack || String(err));
+    process.exit(1);
+  });
+}

--- a/src/scheduler/fsm-effects.ts
+++ b/src/scheduler/fsm-effects.ts
@@ -1,0 +1,25 @@
+// src/scheduler/fsm-effects.ts
+import { Logger } from "../logger";
+import type { AskUserFn } from "./types";
+
+/**
+ * Read user text via a single, unified bridge.
+ * - If an external `readUserLine` is provided, log the prompt and defer to it.
+ * - Otherwise, call the injected `askUser` function (legacy path).
+ */
+export async function getUserText(args: {
+  label: string;
+  prompt: string;
+  readUserLine?: () => Promise<string | undefined>;
+  askUser: AskUserFn;
+  log?: (msg: string) => void;
+}): Promise<string> {
+  const { label, prompt, readUserLine, askUser, log } = args;
+  if (typeof readUserLine === "function") {
+    if (log) log(`[${label}] ${prompt}`);
+    const line = await readUserLine();
+    return (line ?? "").trim();
+  }
+  const text = await askUser(label, prompt);
+  return (text ?? "").trim();
+}

--- a/src/scheduler/fsm-scheduler.ts
+++ b/src/scheduler/fsm-scheduler.ts
@@ -1,4 +1,4 @@
-// fsm-scheduler.ts - Drop-in replacement for RandomScheduler
+// src/scheduler/fsm-scheduler.ts
 import { shuffle as fisherYatesShuffle } from "../utils/shuffle-array";
 import { C, Logger } from "../logger";
 import { NoiseFilters } from "./filters";
@@ -10,129 +10,82 @@ import type { ChatMessage } from "../types";
 import type { SchedulerOptions, AskUserFn } from "./types";
 import { sleep } from "../utils/sleep";
 import { Agent, AgentCallbacks } from "../agents/agent";
+import { getUserText } from "./fsm-effects";
+import { IScheduler } from "./scheduler";
 
+/**
+ * Hooks that the TTY/UI can provide.
+ */
 type Hooks = {
   onStreamStart: () => void;
   onStreamEnd: () => void | Promise<void>;
 };
 
+/** Extend options locally to accept the external prompt bridge without changing the global type. */
 type SchedulerOptionsWithBridge = Hooks &
   SchedulerOptions & {
+    /**
+     * If provided, scheduler will not render its own 'You >' banner or readline.
+     * Instead it awaits this provider and treats the returned line as user input.
+     * This keeps `promptEnabled` semantics (the scheduler still "waits for user"),
+     * but routes I/O through the TTY controller to avoid duplicate listeners.
+     */
     readUserLine?: () => Promise<string | undefined>;
   };
 
-enum SchedulerState {
-  STOPPED = "stopped",
-  IDLE = "idle", 
-  SELECTING_AGENT = "selecting_agent",
-  AGENT_RESPONDING = "agent_responding",
-  WAITING_USER_INPUT = "waiting_user_input",
-  PROCESSING_INTERJECTION = "processing_interjection",
-  PAUSED = "paused",
-  DRAINING = "draining"
+enum State {
+  Init = "Init",
+  Idle = "Idle",
+  SelectAgent = "SelectAgent",
+  RunAgent = "RunAgent",
+  Stopped = "Stopped",
 }
 
-enum SchedulerEvent {
-  START = "start",
-  STOP = "stop",
-  PAUSE = "pause", 
-  RESUME = "resume",
-  BEGIN_DRAIN = "begin_drain",
-  STOP_DRAIN = "stop_drain",
-  WORK_AVAILABLE = "work_available",
-  NO_WORK_AVAILABLE = "no_work_available", 
-  AGENT_SELECTED = "agent_selected",
-  AGENT_COMPLETED = "agent_completed",
-  AGENT_NEEDS_USER = "agent_needs_user",
-  USER_INPUT_RECEIVED = "user_input_received",
-  INTERJECTION_RECEIVED = "interjection_received",
-  INTERJECTION_PROCESSED = "interjection_processed",
-  IDLE_TIMEOUT = "idle_timeout"
-}
-
-interface StateTransition {
-  from: SchedulerState;
-  event: SchedulerEvent;
-  to: SchedulerState;
-  guard?: () => boolean;
-  action?: () => Promise<void> | void;
-}
-
-export class FSMScheduler {
-  private currentState: SchedulerState = SchedulerState.STOPPED;
-  
-  // Preserve original RandomScheduler fields
+/**
+ * FSMScheduler
+ * ------------
+ * A drop-in replacement for RandomScheduler that organizes control flow
+ * around a small, explicit finite state machine. It keeps public methods
+ * and runtime behavior compatible with the existing scheduler, while
+ * factoring user-input reads through a single bridge to avoid "double Enter".
+ */
+export class FSMScheduler implements IScheduler {
+  /** If provided, the UI owns stdin; we just await a line here. */
   readUserLine?: () => Promise<string | undefined>;
+
+  // --- Core collaborators & config ---
   private readonly agents: Agent[];
   private readonly maxTools: number;
   private readonly shuffle: <T>(arr: T[]) => T[];
   private readonly filters = new NoiseFilters();
   private readonly inbox = new Inbox();
 
+  // --- Control flags & state ---
   private running = false;
   private paused = false;
   private draining = false;
-
-  private activeAgent: Agent | undefined;
-  private respondingAgent: Agent | undefined;
-
   private keepAlive: NodeJS.Timeout | null = null;
 
+  private state: State = State.Init;
+  private idleTicks = 0;
+  private rescheduleNow = false;
+
+  // --- Scheduler book-keeping ---
+  private activeAgent: Agent | undefined;
+  private respondingAgent: Agent | undefined;
   private mutedUntil = new Map<string, number>();
   private lastUserDMTarget: string | null = null;
+  private interjection: string | undefined;
 
+  // --- Behavior toggles ---
   private readonly idlePromptEvery = 3;
-
   private readonly askUser: AskUserFn;
   private readonly promptEnabled: boolean;
   private readonly idleSleepMs: number;
 
+  // --- UI hooks ---
   private readonly onStreamStart: Hooks["onStreamStart"];
   private readonly onStreamEnd: Hooks["onStreamEnd"];
-
-  private interjection: string | undefined = undefined;
-  private rescheduleNow = false;
-  private idleTicks = 0;
-
-  // FSM state machine
-  private transitions: StateTransition[] = [
-    // Starting/stopping
-    { from: SchedulerState.STOPPED, event: SchedulerEvent.START, to: SchedulerState.IDLE, action: () => this.onStart() },
-    { from: SchedulerState.IDLE, event: SchedulerEvent.STOP, to: SchedulerState.STOPPED, action: () => this.onStop() },
-    { from: SchedulerState.SELECTING_AGENT, event: SchedulerEvent.STOP, to: SchedulerState.STOPPED, action: () => this.onStop() },
-    { from: SchedulerState.AGENT_RESPONDING, event: SchedulerEvent.STOP, to: SchedulerState.STOPPED, action: () => this.onStop() },
-    { from: SchedulerState.WAITING_USER_INPUT, event: SchedulerEvent.STOP, to: SchedulerState.STOPPED, action: () => this.onStop() },
-
-    // Pause/resume
-    { from: SchedulerState.IDLE, event: SchedulerEvent.PAUSE, to: SchedulerState.PAUSED, action: () => this.onPause() },
-    { from: SchedulerState.SELECTING_AGENT, event: SchedulerEvent.PAUSE, to: SchedulerState.PAUSED, action: () => this.onPause() },
-    { from: SchedulerState.PAUSED, event: SchedulerEvent.RESUME, to: SchedulerState.IDLE, action: () => this.onResume() },
-
-    // Drain mode
-    { from: SchedulerState.IDLE, event: SchedulerEvent.BEGIN_DRAIN, to: SchedulerState.DRAINING, action: () => this.onBeginDrain() },
-    { from: SchedulerState.SELECTING_AGENT, event: SchedulerEvent.BEGIN_DRAIN, to: SchedulerState.DRAINING, action: () => this.onBeginDrain() },
-    { from: SchedulerState.AGENT_RESPONDING, event: SchedulerEvent.BEGIN_DRAIN, to: SchedulerState.DRAINING, action: () => this.onBeginDrain() },
-    { from: SchedulerState.DRAINING, event: SchedulerEvent.STOP_DRAIN, to: SchedulerState.IDLE, action: () => this.onStopDrain() },
-
-    // Normal work flow
-    { from: SchedulerState.IDLE, event: SchedulerEvent.WORK_AVAILABLE, to: SchedulerState.SELECTING_AGENT, action: () => this.resetIdleTicks() },
-    { from: SchedulerState.SELECTING_AGENT, event: SchedulerEvent.AGENT_SELECTED, to: SchedulerState.AGENT_RESPONDING },
-    { from: SchedulerState.AGENT_RESPONDING, event: SchedulerEvent.AGENT_COMPLETED, to: SchedulerState.IDLE, action: () => this.cleanupAgent() },
-    { from: SchedulerState.AGENT_RESPONDING, event: SchedulerEvent.AGENT_NEEDS_USER, to: SchedulerState.WAITING_USER_INPUT },
-
-    // User input handling
-    { from: SchedulerState.WAITING_USER_INPUT, event: SchedulerEvent.USER_INPUT_RECEIVED, to: SchedulerState.PROCESSING_INTERJECTION },
-
-    // Interjections
-    { from: SchedulerState.IDLE, event: SchedulerEvent.INTERJECTION_RECEIVED, to: SchedulerState.PROCESSING_INTERJECTION },
-    { from: SchedulerState.SELECTING_AGENT, event: SchedulerEvent.INTERJECTION_RECEIVED, to: SchedulerState.PROCESSING_INTERJECTION },
-    { from: SchedulerState.PROCESSING_INTERJECTION, event: SchedulerEvent.INTERJECTION_PROCESSED, to: SchedulerState.IDLE, action: () => this.clearInterjection() },
-
-    // Idle handling
-    { from: SchedulerState.IDLE, event: SchedulerEvent.NO_WORK_AVAILABLE, to: SchedulerState.IDLE, action: () => this.incrementIdleTicks() },
-    { from: SchedulerState.IDLE, event: SchedulerEvent.IDLE_TIMEOUT, to: SchedulerState.WAITING_USER_INPUT, guard: () => this.shouldPromptUser() },
-    { from: SchedulerState.SELECTING_AGENT, event: SchedulerEvent.NO_WORK_AVAILABLE, to: SchedulerState.IDLE }
-  ];
 
   constructor(opts: SchedulerOptionsWithBridge) {
     this.onStreamStart = opts.onStreamStart;
@@ -144,302 +97,256 @@ export class FSMScheduler {
 
     this.promptEnabled = !!opts.promptEnabled;
     this.idleSleepMs = opts.idleSleepMs ?? 25;
+
+    // External prompt bridge (owned by TTY controller)
     this.readUserLine = opts.readUserLine;
 
-    for (const a of this.agents) {
-      this.inbox.ensure(a.id);
-    }
+    for (const a of this.agents) this.inbox.ensure(a.id);
   }
 
-  private async transition(event: SchedulerEvent): Promise<boolean> {
-    const applicable = this.transitions.filter(t => 
-      t.from === this.currentState && 
-      t.event === event &&
-      (!t.guard || t.guard())
-    );
-
-    if (applicable.length === 0) {
-      Logger.debug(`FSM: No transition for ${event} from ${this.currentState}`);
-      return false;
-    }
-
-    const transition = applicable[0];
-    Logger.debug(`FSM: ${this.currentState} --${event}--> ${transition.to}`);
-    
-    this.currentState = transition.to;
-    
-    if (transition.action) {
-      await transition.action();
-    }
-    
-    return true;
-  }
-
-  // Main loop - preserves original structure
+  /** Start the scheduler main loop (returns when stopped). */
   async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+
+    this.keepAlive = setInterval(() => {
+      /* keep event loop alive during long idle */
+    }, 30_000);
+
     try {
-      await this.transition(SchedulerEvent.START);
-      
-      while (this.currentState !== SchedulerState.STOPPED) {
-        await this.tick();
-        await sleep(this.idleSleepMs);
+      this.state = State.Init;
+
+      while (this.running) {
+        // Cooperative pause/drain handling
+        if (this.paused || this.draining) {
+          await sleep(25);
+          continue;
+        }
+
+        switch (this.state) {
+          case State.Init: {
+            this.activeAgent = undefined;
+            this.respondingAgent = undefined;
+            this.idleTicks = 0;
+            this.state = State.Idle;
+            break;
+          }
+
+          case State.Idle: {
+            // Process a pending user interjection (e.g., programmatic injection)
+            if (this.interjection) {
+              await this.handleUserInterjection(this.interjection, {
+                defaultTargetId: this.lastUserDMTarget ?? undefined,
+              });
+              this.interjection = undefined;
+              this.rescheduleNow = true;
+            }
+
+            const ready = this.agents.filter((a) => this.inbox.hasWork(a.id));
+            if (ready.length > 0) {
+              this.state = State.SelectAgent;
+              break;
+            }
+
+            // No ready work → idle path (prompt the user periodically)
+            this.idleTicks++;
+            const queuesEmpty = !this.inbox.hasAnyWork();
+
+            if (
+              queuesEmpty &&
+              this.promptEnabled &&
+              typeof this.readUserLine === "function"
+            ) {
+              const preferred = this.lastUserDMTarget ?? this.agents[0]?.id ?? undefined;
+              const line = ((await this.readUserLine()) ?? "").trim();
+              if (line) {
+                await this.handleUserInterjection(line, { defaultTargetId: preferred });
+                this.idleTicks = 0;
+              } else {
+                await sleep(this.idleSleepMs);
+              }
+              break;
+            }
+
+            if (queuesEmpty && (this.idleTicks % this.idlePromptEvery) === 0 && this.promptEnabled) {
+              const peers = this.agents.map((x) => x.id);
+              const dec =
+                this.agents[0]?.guardOnIdle?.({
+                  idleTicks: this.idleTicks,
+                  peers,
+                  queuesEmpty: true,
+                }) || null;
+
+              const preferred = this.lastUserDMTarget ?? this.agents[0]?.id ?? undefined;
+              const prompt =
+                (dec as any)?.askUser ??
+                `(scheduler)
+All agents are idle.
+Type a message. Prefix with @@<agentId> to DM (peers: ${peers.join(
+                  ", "
+                )}). Use @@group for broadcast.`;
+
+              const userText = await getUserText({
+                label: "scheduler",
+                prompt,
+                readUserLine: this.readUserLine,
+                askUser: this.askUser,
+                log: (msg: string) => Logger.info(msg),
+              });
+
+              if (userText) {
+                await this.handleUserInterjection(userText, {
+                  defaultTargetId: preferred,
+                });
+                this.idleTicks = 0;
+              } else {
+                await sleep(this.idleSleepMs);
+              }
+              break;
+            }
+
+            // Cooperative idle
+            await sleep(this.idleSleepMs);
+            break;
+          }
+
+          case State.SelectAgent: {
+            // Determine order of agents to try this tick
+            const ready = this.agents.filter((a) => this.inbox.hasWork(a.id));
+            const order = this.shuffle(ready);
+
+            let advanced = false;
+            for (const agent of order) {
+              if (this.rescheduleNow) break;
+
+              if (this.isMuted(agent.id)) {
+                Logger.debug(`muted: ${agent.id}`);
+                continue;
+              }
+
+              const next = this.respondingAgent ?? agent;
+              this.respondingAgent = undefined;
+
+              const messages = this.inbox.nextPromptFor(next.id);
+              if (messages.length === 0) {
+                Logger.debug(`no work for ${next.id}`);
+                continue;
+              }
+
+              this.activeAgent = next;
+              const didWork = await this.runAgentOnce(next, messages);
+              this.activeAgent = undefined;
+
+              if (didWork) {
+                // Work done → next scheduler tick
+                advanced = true;
+                break;
+              }
+            }
+
+            if (!advanced) {
+              this.state = State.Idle;
+            } else {
+              // If an agent worked, immediately go back to Idle where
+              // we re-check for more ready work or prompt the user.
+              this.state = State.Idle;
+            }
+            break;
+          }
+
+          case State.RunAgent: {
+            // Not used directly; we run inside SelectAgent loop.
+            this.state = State.Idle;
+            break;
+          }
+
+          case State.Stopped:
+          default: {
+            this.running = false;
+            break;
+          }
+        }
       }
     } catch (e) {
       Logger.error("Scheduler start failed.", e);
     } finally {
       for (const agent of this.agents) {
-        agent.save();
+        try { agent.save(); } catch { /* ignore */ }
       }
+
       if (this.keepAlive) {
         clearInterval(this.keepAlive);
         this.keepAlive = null;
       }
+
       this.running = false;
     }
   }
 
-  private async tick(): Promise<void> {
-    switch (this.currentState) {
-      case SchedulerState.PAUSED:
-      case SchedulerState.DRAINING:
-        // Just wait
-        break;
-        
-      case SchedulerState.IDLE:
-        if (this.interjection) {
-          await this.transition(SchedulerEvent.INTERJECTION_RECEIVED);
-        } else if (this.inbox.hasAnyWork()) {
-          await this.transition(SchedulerEvent.WORK_AVAILABLE);
-        } else if (this.isIdleTimeout()) {
-          await this.transition(SchedulerEvent.IDLE_TIMEOUT);
-        } else {
-          await this.transition(SchedulerEvent.NO_WORK_AVAILABLE);
-        }
-        break;
-        
-      case SchedulerState.SELECTING_AGENT:
-        if (this.interjection) {
-          await this.transition(SchedulerEvent.INTERJECTION_RECEIVED);
-        } else {
-          const agent = this.selectNextAgent();
-          if (agent) {
-            this.activeAgent = agent;
-            await this.transition(SchedulerEvent.AGENT_SELECTED);
-          } else {
-            await this.transition(SchedulerEvent.NO_WORK_AVAILABLE);
-          }
-        }
-        break;
-        
-      case SchedulerState.AGENT_RESPONDING:
-        const result = await this.executeAgentWork();
-        if (result.needsUser) {
-          await this.transition(SchedulerEvent.AGENT_NEEDS_USER);
-        } else {
-          await this.transition(SchedulerEvent.AGENT_COMPLETED);
-        }
-        break;
-        
-      case SchedulerState.PROCESSING_INTERJECTION:
-        await this.handleInterjection();
-        await this.transition(SchedulerEvent.INTERJECTION_PROCESSED);
-        break;
-        
-      case SchedulerState.WAITING_USER_INPUT:
-        const input = await this.getUserInput();
-        if (input) {
-          this.interjection = input;
-          await this.transition(SchedulerEvent.USER_INPUT_RECEIVED);
-        }
-        break;
-    }
-  }
-
-  // State actions
-  private onStart(): void {
-    this.running = true;
-    this.keepAlive = setInterval(() => {}, 30_000);
-  }
-
-  private onStop(): void {
+  stop(): void {
     this.running = false;
     Logger.debug("stopped");
   }
 
-  private onPause(): void {
+  pause(): void {
     this.paused = true;
     Logger.debug("paused");
   }
 
-  private onResume(): void {
+  resume(): void {
     this.paused = false;
     Logger.debug("resumed");
   }
 
-  private onBeginDrain(): void {
+  async drain(): Promise<boolean> {
+    if (this.draining) return false;
     this.draining = true;
+    while (this.hasActiveAgent()) {
+      Logger.info(C.magenta(`\nWaiting for agent to complete...`));
+      await sleep(1000);
+    }
+    return true;
   }
 
-  private onStopDrain(): void {
+  stopDraining(): void {
     this.draining = false;
   }
-
-  private resetIdleTicks(): void {
-    this.idleTicks = 0;
+  isDraining(): boolean {
+    return this.draining;
+  }
+  hasActiveAgent(): boolean {
+    return !!this.activeAgent;
   }
 
-  private incrementIdleTicks(): void {
-    this.idleTicks++;
+  async interject(text: string): Promise<void> {
+    this.interjection = text;
   }
 
-  private cleanupAgent(): void {
-    this.activeAgent = undefined;
-  }
-
-  private clearInterjection(): void {
-    this.interjection = undefined;
-    this.rescheduleNow = false;
-  }
-
-  // Guards
-  private shouldPromptUser(): boolean {
-    return !this.inbox.hasAnyWork() && 
-           (this.idleTicks % this.idlePromptEvery) === 0 && 
-           this.promptEnabled;
-  }
-
-  private isIdleTimeout(): boolean {
-    return !this.inbox.hasAnyWork() && 
-           (this.idleTicks % this.idlePromptEvery) === 0 && 
-           this.promptEnabled;
-  }
-
-  // Agent work - preserves original logic
-  private selectNextAgent(): Agent | undefined {
-    const ready = this.agents.filter((a) => this.inbox.hasWork(a.id));
-    const order = this.shuffle(ready);
-    
-    for (const agent of order) {
-      if (this.isMuted(agent.id)) {
-        Logger.debug(`muted: ${agent.id}`);
-        continue;
-      }
-      return this.respondingAgent ?? agent;
-    }
-    return undefined;
-  }
-
-  private async executeAgentWork(): Promise<{needsUser: boolean}> {
-    if (!this.activeAgent) return {needsUser: false};
-
-    const agent = this.activeAgent;
-    this.respondingAgent = undefined;
-
-    const messages = this.inbox.nextPromptFor(agent.id);
-    if (messages.length === 0) {
-      return {needsUser: false};
-    }
-
-    Logger.debug(`drained prompt for ${agent.id}:`, JSON.stringify(messages));
-
-    let remaining = this.maxTools;
-    const messagesIn = [...messages];
-    let needsUser = false;
-
-    try {
-      const callbacks: AgentCallbacks = {
-        onRouteCompleted: async (message, numToolsUsed, askedUser) => {
-          if (numToolsUsed > 0) return false;
-
-          const shouldUserRespond = askedUser || this.agents.length === 1 || !this.inbox.hasAnyWork();
-          if (!shouldUserRespond) return false;
-
-          needsUser = true;
-          this.lastUserDMTarget = agent.id;
-          return true;
-        },
-        shouldAbort: () => this.draining,
-        onStreamStart: this.onStreamStart,
-        onStreamEnd: this.onStreamEnd,
-        onRoute: async (message: string, filters: NoiseFilters): Promise<boolean> => {
-          return await routeWithSideEffects(
-            {
-              agents: this.agents,
-              enqueue: (toId, msg) => this.inbox.push(toId, msg),
-              setRespondingAgent: (id) => {
-                this.respondingAgent = this.agents.find((x) => x.id === id);
-              },
-              applyGuard: (from, dec) => this.applyGuardDecision(agent, dec),
-              setLastUserDMTarget: (id) => {
-                this.lastUserDMTarget = id;
-              },
-            },
-            this,
-            message,
-            filters
-          );
-        }
-      };
-
-      await agent.respond(
-        messagesIn,
-        Math.max(0, remaining),
-        this.filters,
-        this.agents.filter(a => a.id !== agent.id),
-        callbacks
-      );
-
-    } catch (error) {
-      Logger.error(`Agent ${agent.id} execution failed:`, error);
-    }
-
-    return {needsUser};
-  }
-
-  // User input handling - preserves original logic
-  private async getUserInput(): Promise<string | undefined> {
-    if (!this.inbox.hasAnyWork() && this.promptEnabled) {
-      if (typeof this.readUserLine === "function") {
-        return await this.readUserLine();
-      } else {
-        const peers = this.agents.map((x) => x.id);
-        const dec = this.agents[0]?.guardOnIdle?.({
-          idleTicks: this.idleTicks,
-          peers,
-          queuesEmpty: true,
-        }) || null;
-        
-        const prompt = (dec as any)?.askUser ?? 
-          `(scheduler) All agents are idle. Provide the next concrete instruction or question.`;
-        const preferred = this.agents[0]?.id;
-        if (preferred) this.lastUserDMTarget = preferred;
-        
-        return await this.askUser("scheduler", prompt);
-      }
-    }
-    return undefined;
-  }
-
-  private async handleInterjection(): Promise<void> {
-    if (!this.interjection) return;
-
-    await this.handleUserInterjection(this.interjection, {
-      defaultTargetId: this.lastUserDMTarget ?? undefined,
-    });
-  }
-
-  // Preserved from original RandomScheduler
-  private async handleUserInterjection(text: string, opts?: { defaultTargetId?: string }) {
+  /**
+   * Enqueue user text.
+   * - Explicit @@agent tags override everything (reschedule immediately)
+   * - Else, if provided, DM the default target
+   * - Else, broadcast to the group
+   */
+  private async handleUserInterjection(
+    text: string,
+    opts?: { defaultTargetId?: string }
+  ): Promise<void> {
     const raw = String(text ?? "");
     const parts = TagSplitter.split(raw, {
       userTokens: ["user"],
       groupTokens: ["group"],
-      agentTokens: this.agents.map((a) => a.id),
+      agentTokens: this.agents.map((a) => a.id), // allowlist
       fileTokens: ["file"],
       allowFileShorthand: false,
     });
 
-    const agentParts = parts.filter((p) => p.kind === "agent") as Array<TagPart & { kind: "agent" }>;
+    // Explicit @@agent tag(s)
+    const agentParts = parts.filter(
+      (p) => p.kind === "agent"
+    ) as Array<TagPart & { kind: "agent" }>;
+
+    Logger.debug("agentParts", agentParts);
 
     if (agentParts.length > 0) {
       const targets: Agent[] = [];
@@ -453,7 +360,11 @@ export class FSMScheduler {
         for (const ap of agentParts) {
           const ag = this.findAgentByIdExact(ap.tag);
           if (!ag) continue;
-          const msg: ChatMessage = { content: ap.content, role: "user", from: "User" };
+          const msg: ChatMessage = {
+            content: ap.content,
+            role: "user",
+            from: "User",
+          };
           this.inbox.push(ag.id, msg);
           Logger.info(`[user → @@${ag.id}] ${raw}`);
         }
@@ -462,26 +373,34 @@ export class FSMScheduler {
       }
     }
 
+    // DM default target if provided
     if (opts?.defaultTargetId) {
       const ag = this.findAgentByIdExact(opts.defaultTargetId);
       if (ag) {
-        const msg: ChatMessage = { content: raw.trim(), role: "user", from: "User" };
+        const msg: ChatMessage = {
+          content: raw.trim(),
+          role: "user",
+          from: "User",
+        };
         this.respondingAgent = ag;
         this.lastUserDMTarget = ag.id;
         this.inbox.push(ag.id, msg);
-        Logger.info(`[user → @@${ag.id} (def)] ${raw}`);
+        Logger.info(`[user → @@${ag.id}] ${raw}`);
         this.rescheduleNow = true;
         return;
       }
     }
 
+    // Fallback: broadcast to group
     for (const a of this.agents) {
       this.inbox.push(a.id, { content: raw.trim(), role: "user", from: "User" });
     }
+    Logger.debug("End of interjection");
     Logger.info(`[user → @@group] ${raw}`);
   }
 
-  // Utility methods - preserved from original
+  // ------------------------------ Internals ------------------------------
+
   private isMuted(id: string): boolean {
     const until = this.mutedUntil.get(id) ?? 0;
     return Date.now() < until;
@@ -506,20 +425,20 @@ export class FSMScheduler {
       this.mute(agent.id, dec.muteMs);
     }
     if (dec.askUser && this.promptEnabled) {
-      this.lastUserDMTarget = agent.id;
-      const userText = await this.getUserText(agent.id, dec.askUser);
-      if (userText?.trim()) {
-        await this.handleUserInterjection(userText, { defaultTargetId: agent.id });
+      this.lastUserDMTarget = agent.id; // prefer the nudging agent
+      const userText = await getUserText({
+        label: agent.id,
+        prompt: dec.askUser,
+        readUserLine: this.readUserLine,
+        askUser: this.askUser,
+        log: (msg: string) => Logger.info(msg),
+      });
+      if (userText) {
+        await this.handleUserInterjection(userText, {
+          defaultTargetId: agent.id,
+        });
       }
     }
-  }
-
-  private async getUserText(label: string, prompt: string): Promise<string> {
-    if (typeof this.readUserLine === "function") {
-      Logger.info(`[${label}] ${prompt}`);
-      return ((await this.readUserLine()) ?? "").trim();
-    }
-    return ((await this.askUser(label, prompt)) ?? "").trim();
   }
 
   private findAgentByIdExact(key: string): Agent | undefined {
@@ -527,26 +446,80 @@ export class FSMScheduler {
     return this.agents.find((a) => a.id.toLowerCase() === t);
   }
 
-  // Public API - matches original RandomScheduler
-  stop() { this.transition(SchedulerEvent.STOP); }
-  pause() { this.transition(SchedulerEvent.PAUSE); }
-  resume() { this.transition(SchedulerEvent.RESUME); }
+  // Run a single agent once with its drained messages, returning whether
+  // it produced any output (used to decide if we "did work" this tick).
+  private async runAgentOnce(a: Agent, messagesIn: ChatMessage[]): Promise<boolean> {
+    let remaining = this.maxTools;
+    let totalToolsUsed = 0;
+    this.activeAgent = a;
 
-  async drain(): Promise<boolean> {
-    if (this.draining) return false;
-    await this.transition(SchedulerEvent.BEGIN_DRAIN);
-    while (this.hasActiveAgent()) {
-      Logger.info(C.magenta(`\nWaiting for agent to complete...`));
-      await sleep(1000);
+    try {
+      const callbacks: AgentCallbacks = {
+        onRouteCompleted: async (message, numToolsUsed, askedUser) => {
+          if (numToolsUsed > 0) {
+            return false; // If the agent just did a tool call, let it continue
+          }
+
+          const shouldUserRespond =
+            askedUser || this.agents.length === 1 || !this.inbox.hasAnyWork();
+
+          if (!shouldUserRespond) {
+            return false;
+          }
+
+          this.lastUserDMTarget = a.id;
+          const userText = await getUserText({
+            label: a.id,
+            prompt: message,
+            readUserLine: this.readUserLine,
+            askUser: this.askUser,
+            log: (msg: string) => Logger.info(msg),
+          });
+          if (userText) {
+            await this.handleUserInterjection(userText, {
+              defaultTargetId: a.id,
+            });
+          }
+          this.rescheduleNow = true;
+          return true;
+        },
+        shouldAbort: () => this.draining,
+        onStreamStart: this.onStreamStart,
+        onStreamEnd: this.onStreamEnd,
+        onRoute: async (message: string, filters: NoiseFilters) => {
+          return await routeWithSideEffects(
+            {
+              agents: this.agents,
+              enqueue: (toId, msg) => this.inbox.push(toId, msg),
+              setRespondingAgent: (id) => {
+                this.respondingAgent = this.agents.find((x) => x.id === id);
+              },
+              applyGuard: (_from, dec) => this.applyGuardDecision(a, dec),
+              setLastUserDMTarget: (id) => {
+                this.lastUserDMTarget = id;
+              },
+            },
+            this,
+            message,
+            filters
+          );
+        },
+      };
+
+      const peers = this.agents.filter(agent => agent.id !== a.id);
+      const result = await a.respond(
+        messagesIn,
+        Math.max(0, remaining),
+        this.filters,
+        peers,
+        callbacks
+      );
+
+      return (Array.isArray(result) ? result.length > 0 : !!result);
+    } finally {
+      if (totalToolsUsed > 0) {
+        // this.review.markDirty(a.id);
+      }
     }
-    return true;
-  }
-
-  stopDraining(): void { this.transition(SchedulerEvent.STOP_DRAIN); }
-  isDraining(): boolean { return this.draining; }
-  hasActiveAgent(): boolean { return !!this.activeAgent; }
-
-  async interject(text: string) {
-    this.interjection = text;
   }
 }

--- a/src/scheduler/fsm-scheduler.ts
+++ b/src/scheduler/fsm-scheduler.ts
@@ -1,0 +1,552 @@
+// fsm-scheduler.ts - Drop-in replacement for RandomScheduler
+import { shuffle as fisherYatesShuffle } from "../utils/shuffle-array";
+import { C, Logger } from "../logger";
+import { NoiseFilters } from "./filters";
+import { Inbox } from "./inbox";
+import { routeWithSideEffects } from "./router";
+import { TagSplitter, TagPart } from "../utils/tag-splitter";
+import type { GuardDecision } from "../guardrails/guardrail";
+import type { ChatMessage } from "../types";
+import type { SchedulerOptions, AskUserFn } from "./types";
+import { sleep } from "../utils/sleep";
+import { Agent, AgentCallbacks } from "../agents/agent";
+
+type Hooks = {
+  onStreamStart: () => void;
+  onStreamEnd: () => void | Promise<void>;
+};
+
+type SchedulerOptionsWithBridge = Hooks &
+  SchedulerOptions & {
+    readUserLine?: () => Promise<string | undefined>;
+  };
+
+enum SchedulerState {
+  STOPPED = "stopped",
+  IDLE = "idle", 
+  SELECTING_AGENT = "selecting_agent",
+  AGENT_RESPONDING = "agent_responding",
+  WAITING_USER_INPUT = "waiting_user_input",
+  PROCESSING_INTERJECTION = "processing_interjection",
+  PAUSED = "paused",
+  DRAINING = "draining"
+}
+
+enum SchedulerEvent {
+  START = "start",
+  STOP = "stop",
+  PAUSE = "pause", 
+  RESUME = "resume",
+  BEGIN_DRAIN = "begin_drain",
+  STOP_DRAIN = "stop_drain",
+  WORK_AVAILABLE = "work_available",
+  NO_WORK_AVAILABLE = "no_work_available", 
+  AGENT_SELECTED = "agent_selected",
+  AGENT_COMPLETED = "agent_completed",
+  AGENT_NEEDS_USER = "agent_needs_user",
+  USER_INPUT_RECEIVED = "user_input_received",
+  INTERJECTION_RECEIVED = "interjection_received",
+  INTERJECTION_PROCESSED = "interjection_processed",
+  IDLE_TIMEOUT = "idle_timeout"
+}
+
+interface StateTransition {
+  from: SchedulerState;
+  event: SchedulerEvent;
+  to: SchedulerState;
+  guard?: () => boolean;
+  action?: () => Promise<void> | void;
+}
+
+export class FSMScheduler {
+  private currentState: SchedulerState = SchedulerState.STOPPED;
+  
+  // Preserve original RandomScheduler fields
+  readUserLine?: () => Promise<string | undefined>;
+  private readonly agents: Agent[];
+  private readonly maxTools: number;
+  private readonly shuffle: <T>(arr: T[]) => T[];
+  private readonly filters = new NoiseFilters();
+  private readonly inbox = new Inbox();
+
+  private running = false;
+  private paused = false;
+  private draining = false;
+
+  private activeAgent: Agent | undefined;
+  private respondingAgent: Agent | undefined;
+
+  private keepAlive: NodeJS.Timeout | null = null;
+
+  private mutedUntil = new Map<string, number>();
+  private lastUserDMTarget: string | null = null;
+
+  private readonly idlePromptEvery = 3;
+
+  private readonly askUser: AskUserFn;
+  private readonly promptEnabled: boolean;
+  private readonly idleSleepMs: number;
+
+  private readonly onStreamStart: Hooks["onStreamStart"];
+  private readonly onStreamEnd: Hooks["onStreamEnd"];
+
+  private interjection: string | undefined = undefined;
+  private rescheduleNow = false;
+  private idleTicks = 0;
+
+  // FSM state machine
+  private transitions: StateTransition[] = [
+    // Starting/stopping
+    { from: SchedulerState.STOPPED, event: SchedulerEvent.START, to: SchedulerState.IDLE, action: () => this.onStart() },
+    { from: SchedulerState.IDLE, event: SchedulerEvent.STOP, to: SchedulerState.STOPPED, action: () => this.onStop() },
+    { from: SchedulerState.SELECTING_AGENT, event: SchedulerEvent.STOP, to: SchedulerState.STOPPED, action: () => this.onStop() },
+    { from: SchedulerState.AGENT_RESPONDING, event: SchedulerEvent.STOP, to: SchedulerState.STOPPED, action: () => this.onStop() },
+    { from: SchedulerState.WAITING_USER_INPUT, event: SchedulerEvent.STOP, to: SchedulerState.STOPPED, action: () => this.onStop() },
+
+    // Pause/resume
+    { from: SchedulerState.IDLE, event: SchedulerEvent.PAUSE, to: SchedulerState.PAUSED, action: () => this.onPause() },
+    { from: SchedulerState.SELECTING_AGENT, event: SchedulerEvent.PAUSE, to: SchedulerState.PAUSED, action: () => this.onPause() },
+    { from: SchedulerState.PAUSED, event: SchedulerEvent.RESUME, to: SchedulerState.IDLE, action: () => this.onResume() },
+
+    // Drain mode
+    { from: SchedulerState.IDLE, event: SchedulerEvent.BEGIN_DRAIN, to: SchedulerState.DRAINING, action: () => this.onBeginDrain() },
+    { from: SchedulerState.SELECTING_AGENT, event: SchedulerEvent.BEGIN_DRAIN, to: SchedulerState.DRAINING, action: () => this.onBeginDrain() },
+    { from: SchedulerState.AGENT_RESPONDING, event: SchedulerEvent.BEGIN_DRAIN, to: SchedulerState.DRAINING, action: () => this.onBeginDrain() },
+    { from: SchedulerState.DRAINING, event: SchedulerEvent.STOP_DRAIN, to: SchedulerState.IDLE, action: () => this.onStopDrain() },
+
+    // Normal work flow
+    { from: SchedulerState.IDLE, event: SchedulerEvent.WORK_AVAILABLE, to: SchedulerState.SELECTING_AGENT, action: () => this.resetIdleTicks() },
+    { from: SchedulerState.SELECTING_AGENT, event: SchedulerEvent.AGENT_SELECTED, to: SchedulerState.AGENT_RESPONDING },
+    { from: SchedulerState.AGENT_RESPONDING, event: SchedulerEvent.AGENT_COMPLETED, to: SchedulerState.IDLE, action: () => this.cleanupAgent() },
+    { from: SchedulerState.AGENT_RESPONDING, event: SchedulerEvent.AGENT_NEEDS_USER, to: SchedulerState.WAITING_USER_INPUT },
+
+    // User input handling
+    { from: SchedulerState.WAITING_USER_INPUT, event: SchedulerEvent.USER_INPUT_RECEIVED, to: SchedulerState.PROCESSING_INTERJECTION },
+
+    // Interjections
+    { from: SchedulerState.IDLE, event: SchedulerEvent.INTERJECTION_RECEIVED, to: SchedulerState.PROCESSING_INTERJECTION },
+    { from: SchedulerState.SELECTING_AGENT, event: SchedulerEvent.INTERJECTION_RECEIVED, to: SchedulerState.PROCESSING_INTERJECTION },
+    { from: SchedulerState.PROCESSING_INTERJECTION, event: SchedulerEvent.INTERJECTION_PROCESSED, to: SchedulerState.IDLE, action: () => this.clearInterjection() },
+
+    // Idle handling
+    { from: SchedulerState.IDLE, event: SchedulerEvent.NO_WORK_AVAILABLE, to: SchedulerState.IDLE, action: () => this.incrementIdleTicks() },
+    { from: SchedulerState.IDLE, event: SchedulerEvent.IDLE_TIMEOUT, to: SchedulerState.WAITING_USER_INPUT, guard: () => this.shouldPromptUser() },
+    { from: SchedulerState.SELECTING_AGENT, event: SchedulerEvent.NO_WORK_AVAILABLE, to: SchedulerState.IDLE }
+  ];
+
+  constructor(opts: SchedulerOptionsWithBridge) {
+    this.onStreamStart = opts.onStreamStart;
+    this.onStreamEnd = opts.onStreamEnd;
+    this.agents = opts.agents;
+    this.maxTools = opts.maxTools;
+    this.shuffle = opts.shuffle ?? fisherYatesShuffle;
+    this.askUser = opts.onAskUser;
+
+    this.promptEnabled = !!opts.promptEnabled;
+    this.idleSleepMs = opts.idleSleepMs ?? 25;
+    this.readUserLine = opts.readUserLine;
+
+    for (const a of this.agents) {
+      this.inbox.ensure(a.id);
+    }
+  }
+
+  private async transition(event: SchedulerEvent): Promise<boolean> {
+    const applicable = this.transitions.filter(t => 
+      t.from === this.currentState && 
+      t.event === event &&
+      (!t.guard || t.guard())
+    );
+
+    if (applicable.length === 0) {
+      Logger.debug(`FSM: No transition for ${event} from ${this.currentState}`);
+      return false;
+    }
+
+    const transition = applicable[0];
+    Logger.debug(`FSM: ${this.currentState} --${event}--> ${transition.to}`);
+    
+    this.currentState = transition.to;
+    
+    if (transition.action) {
+      await transition.action();
+    }
+    
+    return true;
+  }
+
+  // Main loop - preserves original structure
+  async start(): Promise<void> {
+    try {
+      await this.transition(SchedulerEvent.START);
+      
+      while (this.currentState !== SchedulerState.STOPPED) {
+        await this.tick();
+        await sleep(this.idleSleepMs);
+      }
+    } catch (e) {
+      Logger.error("Scheduler start failed.", e);
+    } finally {
+      for (const agent of this.agents) {
+        agent.save();
+      }
+      if (this.keepAlive) {
+        clearInterval(this.keepAlive);
+        this.keepAlive = null;
+      }
+      this.running = false;
+    }
+  }
+
+  private async tick(): Promise<void> {
+    switch (this.currentState) {
+      case SchedulerState.PAUSED:
+      case SchedulerState.DRAINING:
+        // Just wait
+        break;
+        
+      case SchedulerState.IDLE:
+        if (this.interjection) {
+          await this.transition(SchedulerEvent.INTERJECTION_RECEIVED);
+        } else if (this.inbox.hasAnyWork()) {
+          await this.transition(SchedulerEvent.WORK_AVAILABLE);
+        } else if (this.isIdleTimeout()) {
+          await this.transition(SchedulerEvent.IDLE_TIMEOUT);
+        } else {
+          await this.transition(SchedulerEvent.NO_WORK_AVAILABLE);
+        }
+        break;
+        
+      case SchedulerState.SELECTING_AGENT:
+        if (this.interjection) {
+          await this.transition(SchedulerEvent.INTERJECTION_RECEIVED);
+        } else {
+          const agent = this.selectNextAgent();
+          if (agent) {
+            this.activeAgent = agent;
+            await this.transition(SchedulerEvent.AGENT_SELECTED);
+          } else {
+            await this.transition(SchedulerEvent.NO_WORK_AVAILABLE);
+          }
+        }
+        break;
+        
+      case SchedulerState.AGENT_RESPONDING:
+        const result = await this.executeAgentWork();
+        if (result.needsUser) {
+          await this.transition(SchedulerEvent.AGENT_NEEDS_USER);
+        } else {
+          await this.transition(SchedulerEvent.AGENT_COMPLETED);
+        }
+        break;
+        
+      case SchedulerState.PROCESSING_INTERJECTION:
+        await this.handleInterjection();
+        await this.transition(SchedulerEvent.INTERJECTION_PROCESSED);
+        break;
+        
+      case SchedulerState.WAITING_USER_INPUT:
+        const input = await this.getUserInput();
+        if (input) {
+          this.interjection = input;
+          await this.transition(SchedulerEvent.USER_INPUT_RECEIVED);
+        }
+        break;
+    }
+  }
+
+  // State actions
+  private onStart(): void {
+    this.running = true;
+    this.keepAlive = setInterval(() => {}, 30_000);
+  }
+
+  private onStop(): void {
+    this.running = false;
+    Logger.debug("stopped");
+  }
+
+  private onPause(): void {
+    this.paused = true;
+    Logger.debug("paused");
+  }
+
+  private onResume(): void {
+    this.paused = false;
+    Logger.debug("resumed");
+  }
+
+  private onBeginDrain(): void {
+    this.draining = true;
+  }
+
+  private onStopDrain(): void {
+    this.draining = false;
+  }
+
+  private resetIdleTicks(): void {
+    this.idleTicks = 0;
+  }
+
+  private incrementIdleTicks(): void {
+    this.idleTicks++;
+  }
+
+  private cleanupAgent(): void {
+    this.activeAgent = undefined;
+  }
+
+  private clearInterjection(): void {
+    this.interjection = undefined;
+    this.rescheduleNow = false;
+  }
+
+  // Guards
+  private shouldPromptUser(): boolean {
+    return !this.inbox.hasAnyWork() && 
+           (this.idleTicks % this.idlePromptEvery) === 0 && 
+           this.promptEnabled;
+  }
+
+  private isIdleTimeout(): boolean {
+    return !this.inbox.hasAnyWork() && 
+           (this.idleTicks % this.idlePromptEvery) === 0 && 
+           this.promptEnabled;
+  }
+
+  // Agent work - preserves original logic
+  private selectNextAgent(): Agent | undefined {
+    const ready = this.agents.filter((a) => this.inbox.hasWork(a.id));
+    const order = this.shuffle(ready);
+    
+    for (const agent of order) {
+      if (this.isMuted(agent.id)) {
+        Logger.debug(`muted: ${agent.id}`);
+        continue;
+      }
+      return this.respondingAgent ?? agent;
+    }
+    return undefined;
+  }
+
+  private async executeAgentWork(): Promise<{needsUser: boolean}> {
+    if (!this.activeAgent) return {needsUser: false};
+
+    const agent = this.activeAgent;
+    this.respondingAgent = undefined;
+
+    const messages = this.inbox.nextPromptFor(agent.id);
+    if (messages.length === 0) {
+      return {needsUser: false};
+    }
+
+    Logger.debug(`drained prompt for ${agent.id}:`, JSON.stringify(messages));
+
+    let remaining = this.maxTools;
+    const messagesIn = [...messages];
+    let needsUser = false;
+
+    try {
+      const callbacks: AgentCallbacks = {
+        onRouteCompleted: async (message, numToolsUsed, askedUser) => {
+          if (numToolsUsed > 0) return false;
+
+          const shouldUserRespond = askedUser || this.agents.length === 1 || !this.inbox.hasAnyWork();
+          if (!shouldUserRespond) return false;
+
+          needsUser = true;
+          this.lastUserDMTarget = agent.id;
+          return true;
+        },
+        shouldAbort: () => this.draining,
+        onStreamStart: this.onStreamStart,
+        onStreamEnd: this.onStreamEnd,
+        onRoute: async (message: string, filters: NoiseFilters): Promise<boolean> => {
+          return await routeWithSideEffects(
+            {
+              agents: this.agents,
+              enqueue: (toId, msg) => this.inbox.push(toId, msg),
+              setRespondingAgent: (id) => {
+                this.respondingAgent = this.agents.find((x) => x.id === id);
+              },
+              applyGuard: (from, dec) => this.applyGuardDecision(agent, dec),
+              setLastUserDMTarget: (id) => {
+                this.lastUserDMTarget = id;
+              },
+            },
+            this,
+            message,
+            filters
+          );
+        }
+      };
+
+      await agent.respond(
+        messagesIn,
+        Math.max(0, remaining),
+        this.filters,
+        this.agents.filter(a => a.id !== agent.id),
+        callbacks
+      );
+
+    } catch (error) {
+      Logger.error(`Agent ${agent.id} execution failed:`, error);
+    }
+
+    return {needsUser};
+  }
+
+  // User input handling - preserves original logic
+  private async getUserInput(): Promise<string | undefined> {
+    if (!this.inbox.hasAnyWork() && this.promptEnabled) {
+      if (typeof this.readUserLine === "function") {
+        return await this.readUserLine();
+      } else {
+        const peers = this.agents.map((x) => x.id);
+        const dec = this.agents[0]?.guardOnIdle?.({
+          idleTicks: this.idleTicks,
+          peers,
+          queuesEmpty: true,
+        }) || null;
+        
+        const prompt = (dec as any)?.askUser ?? 
+          `(scheduler) All agents are idle. Provide the next concrete instruction or question.`;
+        const preferred = this.agents[0]?.id;
+        if (preferred) this.lastUserDMTarget = preferred;
+        
+        return await this.askUser("scheduler", prompt);
+      }
+    }
+    return undefined;
+  }
+
+  private async handleInterjection(): Promise<void> {
+    if (!this.interjection) return;
+
+    await this.handleUserInterjection(this.interjection, {
+      defaultTargetId: this.lastUserDMTarget ?? undefined,
+    });
+  }
+
+  // Preserved from original RandomScheduler
+  private async handleUserInterjection(text: string, opts?: { defaultTargetId?: string }) {
+    const raw = String(text ?? "");
+    const parts = TagSplitter.split(raw, {
+      userTokens: ["user"],
+      groupTokens: ["group"],
+      agentTokens: this.agents.map((a) => a.id),
+      fileTokens: ["file"],
+      allowFileShorthand: false,
+    });
+
+    const agentParts = parts.filter((p) => p.kind === "agent") as Array<TagPart & { kind: "agent" }>;
+
+    if (agentParts.length > 0) {
+      const targets: Agent[] = [];
+      for (const ap of agentParts) {
+        const ag = this.findAgentByIdExact(ap.tag);
+        if (ag && !targets.some((t) => t.id === ag.id)) targets.push(ag);
+      }
+      if (targets.length > 0) {
+        this.respondingAgent = targets[0];
+        this.lastUserDMTarget = targets[0].id;
+        for (const ap of agentParts) {
+          const ag = this.findAgentByIdExact(ap.tag);
+          if (!ag) continue;
+          const msg: ChatMessage = { content: ap.content, role: "user", from: "User" };
+          this.inbox.push(ag.id, msg);
+          Logger.info(`[user → @@${ag.id}] ${raw}`);
+        }
+        this.rescheduleNow = true;
+        return;
+      }
+    }
+
+    if (opts?.defaultTargetId) {
+      const ag = this.findAgentByIdExact(opts.defaultTargetId);
+      if (ag) {
+        const msg: ChatMessage = { content: raw.trim(), role: "user", from: "User" };
+        this.respondingAgent = ag;
+        this.lastUserDMTarget = ag.id;
+        this.inbox.push(ag.id, msg);
+        Logger.info(`[user → @@${ag.id} (def)] ${raw}`);
+        this.rescheduleNow = true;
+        return;
+      }
+    }
+
+    for (const a of this.agents) {
+      this.inbox.push(a.id, { content: raw.trim(), role: "user", from: "User" });
+    }
+    Logger.info(`[user → @@group] ${raw}`);
+  }
+
+  // Utility methods - preserved from original
+  private isMuted(id: string): boolean {
+    const until = this.mutedUntil.get(id) ?? 0;
+    return Date.now() < until;
+  }
+
+  private mute(id: string, ms: number) {
+    this.mutedUntil.set(id, Date.now() + Math.max(250, ms));
+  }
+
+  private async applyGuardDecision(agent: Agent, dec: GuardDecision) {
+    if (dec.warnings && dec.warnings.length) {
+      Logger.debug(`[guard][${agent.id}] ` + (dec as any).warnings.join("; "));
+    }
+    if (dec.nudge) {
+      this.inbox.push(agent.id, {
+        content: dec.nudge,
+        from: "System",
+        role: "system",
+      });
+    }
+    if (dec.muteMs && dec.muteMs > 0) {
+      this.mute(agent.id, dec.muteMs);
+    }
+    if (dec.askUser && this.promptEnabled) {
+      this.lastUserDMTarget = agent.id;
+      const userText = await this.getUserText(agent.id, dec.askUser);
+      if (userText?.trim()) {
+        await this.handleUserInterjection(userText, { defaultTargetId: agent.id });
+      }
+    }
+  }
+
+  private async getUserText(label: string, prompt: string): Promise<string> {
+    if (typeof this.readUserLine === "function") {
+      Logger.info(`[${label}] ${prompt}`);
+      return ((await this.readUserLine()) ?? "").trim();
+    }
+    return ((await this.askUser(label, prompt)) ?? "").trim();
+  }
+
+  private findAgentByIdExact(key: string): Agent | undefined {
+    const t = key.toLowerCase();
+    return this.agents.find((a) => a.id.toLowerCase() === t);
+  }
+
+  // Public API - matches original RandomScheduler
+  stop() { this.transition(SchedulerEvent.STOP); }
+  pause() { this.transition(SchedulerEvent.PAUSE); }
+  resume() { this.transition(SchedulerEvent.RESUME); }
+
+  async drain(): Promise<boolean> {
+    if (this.draining) return false;
+    await this.transition(SchedulerEvent.BEGIN_DRAIN);
+    while (this.hasActiveAgent()) {
+      Logger.info(C.magenta(`\nWaiting for agent to complete...`));
+      await sleep(1000);
+    }
+    return true;
+  }
+
+  stopDraining(): void { this.transition(SchedulerEvent.STOP_DRAIN); }
+  isDraining(): boolean { return this.draining; }
+  hasActiveAgent(): boolean { return !!this.activeAgent; }
+
+  async interject(text: string) {
+    this.interjection = text;
+  }
+}

--- a/src/scheduler/random-scheduler.ts
+++ b/src/scheduler/random-scheduler.ts
@@ -13,6 +13,7 @@ import type {
 } from "./types";
 import { sleep } from "../utils/sleep";
 import { Agent, AgentCallbacks } from "../agents/agent";
+import { IScheduler } from "./scheduler";
 
 type Hooks = {
   onStreamStart: () => void;
@@ -47,7 +48,7 @@ type SchedulerOptionsWithBridge = Hooks &
  *  - Added *external prompt bridge* (`readUserLine`) so the UI (TTY controller) can
  *    own the prompt/echo while the scheduler retains turn/state logic.
  */
-export class RandomScheduler {
+export class RandomScheduler implements IScheduler {
   /**
    * If provided, scheduler will not render its own 'You >' banner or readline.
    * Instead it awaits this provider and treats the returned line as user input.

--- a/src/scheduler/random-scheduler.ts
+++ b/src/scheduler/random-scheduler.ts
@@ -487,5 +487,3 @@ All agents are idle. Provide the next concrete instruction or question.`;
     return new Promise<void>((r) => setTimeout(r, ms));
   }
 }
-
-export default RandomScheduler;

--- a/src/scheduler/random-scheduler.ts
+++ b/src/scheduler/random-scheduler.ts
@@ -165,6 +165,7 @@ export class RandomScheduler implements IScheduler {
         try {
           const callbacks: AgentCallbacks = {
             onRouteCompleted: async (message, numToolsUsed, askedUser) => {
+              //
               if (numToolsUsed > 0) {
                 return false; //If the agent just did a tool call, let it continue
               }
@@ -199,7 +200,7 @@ export class RandomScheduler implements IScheduler {
                   setRespondingAgent: (id) => {
                     this.respondingAgent = this.agents.find((x) => x.id === id);
                   },
-                  applyGuard: (from, dec) => this.applyGuardDecision(agent, dec),
+                  applyGuard: async (from, dec) => this.applyGuardDecision(agent, dec),
                   setLastUserDMTarget: (id) => {
                     this.lastUserDMTarget = id;
                   },


### PR DESCRIPTION
## Description
< Enter a description >


## PR Checklist: Sandbox Matrix (8/8 must pass)

> **Pre-flight once per branch**
>
> ```bash
> # make sure the image exists
> ./create-container.sh     # or ./install.sh
>
> # start clean (optional but recommended)
> rm -rf .org/runs .org/logs
> ```
>
> All commands below assume the repo root. Replace `<CMD>` with the command you want the step to run.
> For “env propagation” checks we use `printenv | grep -E '^ORG_TEST=' || echo missing`.

### Legend

* **UI**: `--ui console` or `--ui tmux`
* **Mode**:

  * **non-interactive** → one step, captured output (uses `sandboxedSh`)
  * **interactive** → one interactive step (uses `shInteractive`)
* **Backend**:

  * **none** → no nested container; run directly in the app container
  * **podman** → nested container runner

---

### ✅ 1. console • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * `.org/logs/*` has no “posix\_spawn 'bash'” errors

* [ ] PASS

---

### ✅ 2. console • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'run `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No crash/stacktrace
  * A single container session reused across steps (check `podman ps` name is stable)

* [ ] PASS

---

### ✅ 3. console • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

  > If your prompt driver doesn’t support the `interactive` keyword, trigger an interactive step via the UI or your testing harness; the key is to exercise `shInteractive`.

* **Expect**

  * Output contains `ORG_TEST=1`
  * **No** “posix\_spawn 'bash' ENOENT” anywhere

* [ ] PASS

---

### ✅ 4. console • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui console --prompt 'interactive `printenv | grep -E "^ORG_TEST=" || echo missing`'
  ```

* **Expect**

  * Output contains `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * Still only **one** container for the app and **one** nested podman for the step (if you keep nesting enabled); or none if your launcher sets `ORG_SANDBOX_BACKEND=none`

* [ ] PASS

---

### ✅ 5. tmux • non-interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the tmux pane, run:

  ```
  run `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **ESC** emits the ACK and exits gracefully
  * **Ctrl+C** exits immediately (130)

* [ ] PASS

---

### ✅ 6. tmux • non-interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane, run the same `printenv` step.

* **Expect**

  * Pane prints `ORG_TEST=1`
  * ESC ACK works; Ctrl+C exits immediately
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 7. tmux • interactive • backend=none

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=none \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * **Typing** must not crash the app (regression test from ESC/Ctrl+C fixes)
  * No “posix\_spawn 'bash' ENOENT”

* [ ] PASS

---

### ✅ 8. tmux • interactive • backend=podman

* **Run**

  ```bash
  ORG_TEST=1 LOG_LEVEL=debug SANDBOX_BACKEND=podman \
  org --ui tmux
  ```

  In the pane:

  ```
  interactive `printenv | grep -E "^ORG_TEST=" || echo missing`
  ```

* **Expect**

  * Pane prints `ORG_TEST=1`
  * No “posix\_spawn 'bash' ENOENT”
  * No extra containers spawned when not intended (depending on your launcher policy)

* [ ] PASS

---

## Add-on checks (tick if relevant to your PR)

* [ ] **ESC ack** works in console & tmux (no double-ACK, no freeze)
* [ ] **Ctrl+C** exits with code 130
* [ ] All step artifacts exist (`.org/runs/<id>/steps/step-*.{out,err,meta.json}`)
* [ ] No “sticky runner” surprises: `/work/.org/org-step.sh` is a fresh copy if the script changed
* [ ] CI logs contain no “posix\_spawn 'bash' ENOENT” or uncaught exceptions

---

## How to use this locally

* Run each command and tick the checkbox.
* If a tmux test fails, open `.org/logs/tmux-*.log` for the run and attach to your PR.
* If a console test fails, attach `.org/logs/*` and the newest `.org/runs/<id>/steps/` files.


